### PR TITLE
docs: PokeAPI 사용 방식 개선 제안

### DIFF
--- a/reviews/2026040616_PokeAPI_개선제안.md
+++ b/reviews/2026040616_PokeAPI_개선제안.md
@@ -1,0 +1,267 @@
+# PokeAPI 사용 방식 개선 제안
+
+> 작성일: 2026-04-06
+> 대상: 포켓몬 도감 목록 조회 및 한글 이름 매핑
+
+---
+
+## 1. 현재 구조
+
+```
+pokemon_full_ko.json (1025건, no + name만 보유)
+         │
+         ▼
+    페이지 렌더링 시 12건씩 개별 fetch
+         │
+         ▼
+https://pokeapi.co/api/v2/pokemon/{id}  ← 페이지당 12번 호출
+```
+
+### 도감 목록 (`pokedex.js`)
+
+1. 앱 초기화 시 `/pokemon_full_ko.json`을 fetch하여 전체 1025건의 `{ no, name }` 데이터를 로드
+2. 사이드바와 검색은 이 로컬 데이터로 처리
+3. **그리드 렌더링 시** 현재 페이지의 12건에 대해 각각 `https://pokeapi.co/api/v2/pokemon/{id}`를 호출
+
+```js
+// src/components/pokedex/pokedex.js 49~53번째 줄
+const promises = pageItems.map((p) =>
+  fetch(`https://pokeapi.co/api/v2/pokemon/${p.no}`).then((r) => r.json()),
+);
+const details = await Promise.all(promises);
+```
+
+4. 응답에서 `sprites.other["official-artwork"].front_default`(이미지)와 `types`(타입)를 사용
+
+### 나만의 파티 (`myparty.js`)
+
+1. `/public/pokemon_full_ko.json`을 fetch하여 한글 이름 맵 생성
+2. 북마크된 포켓몬 ID 배열을 받아 각 ID별로 `https://pokeapi.co/api/v2/pokemon/{id}`를 호출
+
+---
+
+## 2. 발견된 문제점
+
+### 2-1. 페이지 이동마다 12번의 API 호출 (성능)
+
+페이지를 넘길 때마다 12번의 네트워크 요청이 발생합니다. 1025건 기준으로 86페이지가 있으므로, 전체를 탐색하면 최대 1025번의 API 호출이 필요합니다.
+
+PokeAPI의 개별 상세 응답은 **약 30~50KB**로, 실제로 사용하는 데이터(이미지 URL, 타입)에 비해 불필요한 데이터가 대부분입니다(stats, moves, abilities, game_indices 등).
+
+### 2-2. 이미지 URL은 API 호출 없이 생성 가능
+
+PokeAPI 스프라이트 URL은 ID 기반으로 **완전히 예측 가능한 패턴**입니다:
+
+| 이미지 종류 | URL 패턴 |
+|------------|----------|
+| 공식 아트워크 (현재 사용 중) | `https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/{id}.png` |
+| 기본 스프라이트 | `https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/{id}.png` |
+| Home (고해상도) | `https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/{id}.png` |
+| Dream World (SVG) | `https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/dream-world/{id}.svg` |
+
+현재 `pokedexUI.js`에서 사용하는 이미지:
+```js
+const img = data.sprites.other["official-artwork"].front_default;
+```
+
+이 URL은 `https://raw.githubusercontent.com/.../official-artwork/{id}.png`과 동일합니다. **API를 호출하지 않고 ID만으로 바로 만들 수 있습니다.**
+
+### 2-3. 로컬 JSON에 타입 데이터 부재
+
+`pokemon_full_ko.json`에는 `no`와 `name`만 있어서, 타입 정보(grass, fire 등)를 얻기 위해 API를 호출할 수밖에 없는 구조입니다.
+
+```json
+// 현재 — 타입 정보 없음
+{ "no": 1, "name": "이상해씨" }
+```
+
+### 2-4. `myparty.js`의 한글 이름 매핑 버그
+
+`myparty.js`에서 JSON을 읽을 때 `p.id`로 접근하지만, 실제 JSON 필드명은 `no`입니다:
+
+```js
+// src/scripts/myparty.js 59~60번째 줄
+json.forEach((p) => { koNameMap[p.id] = p.name; });
+//                              ^^^^ 버그: JSON에는 'id'가 아니라 'no'
+```
+
+이 때문에 `koNameMap`이 항상 빈 객체가 되어, 한글 이름 매핑이 실패하고 영문 이름이 표시됩니다.
+
+### 2-5. `myparty.js`의 JSON 경로 오류
+
+```js
+// src/scripts/myparty.js 57번째 줄
+const res = await fetch("/public/pokemon_full_ko.json");
+//                       ^^^^^^^ Vite에서는 /public 없이 접근해야 함
+```
+
+Vite에서 `public/` 폴더 안의 파일은 `/`로 접근합니다. `pokedex.js`에서는 올바르게 `/pokemon_full_ko.json`으로 접근하고 있습니다.
+
+---
+
+## 3. 개선 제안
+
+### 제안 A: 로컬 JSON 확장 + 이미지 URL 직접 생성 (추천)
+
+**난이도: 낮음 / 효과: 페이지당 API 12회 → 0회**
+
+`pokemon_full_ko.json`에 타입 정보를 추가합니다:
+
+```json
+{
+  "no": 1,
+  "name": "이상해씨",
+  "types": ["grass", "poison"]
+}
+```
+
+이미지는 ID에서 URL을 바로 생성합니다:
+
+```js
+// 변경 전 — API 12번 호출
+async function renderGrid(page) {
+  const pageItems = filteredPokemon.slice(start, start + ITEMS_PER_PAGE);
+  const promises = pageItems.map((p) =>
+    fetch(`https://pokeapi.co/api/v2/pokemon/${p.no}`).then((r) => r.json()),
+  );
+  const details = await Promise.all(promises);
+  // ...
+}
+
+// 변경 후 — API 호출 0번
+function renderGrid(page) {
+  const pageItems = filteredPokemon.slice(start, start + ITEMS_PER_PAGE);
+  pageItems.forEach((p) => {
+    const data = {
+      id: p.no,
+      types: p.types.map((t) => ({ type: { name: t } })),
+      sprites: {
+        other: {
+          "official-artwork": {
+            front_default: `https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/${p.no}.png`,
+          },
+        },
+      },
+    };
+    // PokemonCard(data, p.name) 그대로 사용 가능
+  });
+}
+```
+
+**장점:**
+- 페이지 이동이 즉시 반응 (네트워크 대기 없음)
+- 오프라인에서도 이미지 URL까지 렌더링 가능 (이미지 자체는 CDN 필요)
+- 기존 `PokemonCard` 컴포넌트 수정 최소화
+
+### 제안 B: PokeAPI GraphQL 활용
+
+**난이도: 중간 / 효과: 페이지당 12회 → 1회, 로컬 JSON 제거 가능**
+
+PokeAPI는 GraphQL 엔드포인트(`https://beta.pokeapi.co/graphql/v1beta`)를 제공합니다. 한 번의 요청으로 포켓몬 목록, 한글 이름, 타입, 한글 타입명까지 가져올 수 있습니다:
+
+```graphql
+{
+  pokemon_v2_pokemon(limit: 12, offset: 0, where: {id: {_lte: 1025}}) {
+    id
+    pokemon_v2_pokemontypes {
+      pokemon_v2_type {
+        name
+        pokemon_v2_typenames(where: {pokemon_v2_language: {name: {_eq: "ko"}}}) {
+          name
+        }
+      }
+    }
+    pokemon_v2_pokemonspecy {
+      pokemon_v2_pokemonspeciesnames(where: {pokemon_v2_language: {name: {_eq: "ko"}}}) {
+        name
+      }
+    }
+  }
+}
+```
+
+```js
+// 사용 예시
+async function fetchPokemonPage(page, perPage) {
+  const offset = (page - 1) * perPage;
+  const res = await fetch("https://beta.pokeapi.co/graphql/v1beta", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      query: `{
+        pokemon_v2_pokemon(limit: ${perPage}, offset: ${offset}, where: {id: {_lte: 1025}}) {
+          id
+          pokemon_v2_pokemontypes {
+            pokemon_v2_type {
+              name
+            }
+          }
+          pokemon_v2_pokemonspecy {
+            pokemon_v2_pokemonspeciesnames(where: {pokemon_v2_language: {name: {_eq: "ko"}}}) {
+              name
+            }
+          }
+        }
+      }`,
+    }),
+  });
+  return res.json();
+}
+```
+
+**장점:**
+- `pokemon_full_ko.json` 파일이 불필요해짐
+- API에서 한글 이름을 직접 제공하므로 별도 매핑 불필요
+- 한글 타입명도 가져올 수 있음 (풀, 독, 불꽃, 물 등)
+
+**단점:**
+- `beta` 엔드포인트이므로 안정성 확인 필요
+- 초기 로딩 시 네트워크 의존
+
+### 제안 C: 한글 이름 매핑 버그 수정 (즉시 적용)
+
+**난이도: 매우 낮음**
+
+```js
+// src/scripts/myparty.js — 수정 필요 (2곳)
+
+// 1) 경로 수정: /public 제거
+const res = await fetch("/pokemon_full_ko.json");
+
+// 2) 키 수정: p.id → p.no
+json.forEach((p) => { koNameMap[p.no] = p.name; });
+```
+
+---
+
+## 4. 비교 요약
+
+| 항목 | 현재 | 제안 A (JSON 확장) | 제안 B (GraphQL) |
+|------|------|-------------------|-----------------|
+| 페이지당 API 호출 | 12회 | **0회** | **1회** |
+| 한글 이름 소스 | 로컬 JSON | 로컬 JSON | API 직접 제공 |
+| 타입 데이터 소스 | API 매번 호출 | 로컬 JSON | API 1회 호출 |
+| 이미지 URL | API 응답에서 추출 | ID 패턴으로 생성 | ID 패턴으로 생성 |
+| 오프라인 동작 | 불가 | 가능 (이미지 제외) | 불가 |
+| 구현 난이도 | - | 낮음 | 중간 |
+| 페이지 전환 체감 속도 | 느림 (네트워크 대기) | **즉시** | 빠름 |
+
+---
+
+## 5. 권장 실행 순서
+
+1. **제안 C 즉시 적용** — `myparty.js`의 `p.id` → `p.no` 버그 수정 + `/public` 경로 수정
+2. **제안 A 적용** — `pokemon_full_ko.json`에 types 추가 + `renderGrid()`에서 API 호출 제거
+3. **(선택) 제안 B 검토** — 타입의 한글 번역이 필요하거나, 로컬 JSON 유지보수가 부담되면 GraphQL 전환 고려
+
+---
+
+## 참고: PokeAPI 주요 스펙
+
+- **REST 엔드포인트**: `https://pokeapi.co/api/v2/`
+- **GraphQL 엔드포인트**: `https://beta.pokeapi.co/graphql/v1beta`
+- **인증**: 불필요 (무료, 오픈 API)
+- **캐시**: `Cache-Control: public, max-age=86400` (24시간)
+- **레이트 리밋**: 공식적으로 없음 (CDN 캐시 기반, 과도한 요청 시 차단 가능)
+- **총 포켓몬 수**: 1025종 (폼 변환 포함 시 1350+)
+- **한글 이름 제공**: `pokemon-species/{id}` → `names` 배열에서 `language.name === "ko"` 필터


### PR DESCRIPTION
## Summary
- 포켓몬 도감 목록 조회 시 PokeAPI 사용 패턴을 분석하고 개선안을 제안합니다
- 페이지당 12회 API 호출 → 0회로 줄이는 방법, 한글 이름 매핑 버그 수정 포함
- 3가지 개선안 (로컬 JSON 확장 / GraphQL 전환 / 즉시 버그 수정) 비교 정리

## 주요 발견 사항
- **스프라이트 URL이 ID 기반 패턴으로 예측 가능** — API 호출 없이 이미지 URL 생성 가능
- **`myparty.js`에서 `p.id` → `p.no` 버그** — 한글 이름 매핑이 항상 실패하는 상태
- **`myparty.js`에서 `/public/pokemon_full_ko.json` 경로 오류** — Vite 빌드 후 동작 불가
- **PokeAPI GraphQL 엔드포인트** — 한글 이름 + 타입을 1회 요청으로 획득 가능

## 문서 위치
- `reviews/2026040616_PokeAPI_개선제안.md`

## Test plan
- [ ] 문서 내용 검토
- [ ] 제안 C (즉시 버그 수정) 우선 적용 여부 논의
- [ ] 제안 A (JSON 확장) 적용 시 pokemon_full_ko.json에 types 필드 추가 작업 할당

🤖 Generated with [Claude Code](https://claude.com/claude-code)