### PR TITLE
docs(review): 4차 증분 코드 리뷰 — API 연동 코드 점검

### DIFF
--- a/reviews/2026040711_리뷰.md
+++ b/reviews/2026040711_리뷰.md
@@ -1,0 +1,744 @@
+# 프로젝트 코드 리뷰
+
+> 리뷰 날짜: 2026-04-07
+> 대상: 포켓아카이브 (Pocket Archive) — 포켓몬 도감과 커뮤니티 기능을 함께 제공하는 Vanilla JS 웹 서비스
+> 이전 리뷰: [2026040615_리뷰.md](./2026040615_리뷰.md)
+
+---
+
+## 0. 이번 리뷰 범위
+
+이번 리뷰는 이전 리뷰(2026040615) 이후 **변경된 파일만** 대상으로 합니다.
+
+**변경된 파일:**
+- `src/components/(Auth)/login.js` — 로그인 API 연동 (fetch + localStorage 토큰 저장)
+- `src/components/(Auth)/register.js` — 회원가입 API 연동 (닉네임/아이디 중복확인, 회원가입 요청)
+- `src/components/board/boardDetail.js` — 게시글/댓글 API 연동 시도 + 댓글 등록 API
+- `src/components/header.js` — 로그인/로그아웃 버튼 토글 + logout 함수
+- `src/components/pokedex/pokedex.js` — 내 포켓몬 목록 API 연동 + 등록/삭제 API
+- `src/components/pokedex/pokedexUI.js` — 포켓몬 카드에 몬스터볼 북마크 버튼 추가 + `import dotenv`
+- `src/main.js` — 마이페이지 import 추가, detailPost setTimeout 변경, postId 동적 전달
+- `src/api/post.js` — 새 파일 (빈 파일)
+- `src/api/user.js` — 새 파일 (빈 파일)
+
+**이전 리뷰 해결된 항목:**
+잘했어요! 아래 항목은 이전 리뷰 이후 잘 수정되었어요.
+- ~~이전 3-2. postId 하드코딩~~ — `initPostDetail(postId || 2)`로 변경 완료! URL에서 추출한 postId를 사용하고 있어요.
+
+**이전 리뷰 미해결 항목:**
+아래 항목들은 이전 리뷰에서 지적되었지만 아직 수정되지 않았어요. 이전 리뷰를 참고해주세요.
+- 3-1. DOM 삽입 전 initPostDetail 호출 → [이전 리뷰에서 확인하기](./2026040615_리뷰.md#3-1-게시글-상세---dom이-없을-때-initpostdetail-호출-중요도-높음) (setTimeout(2ms)로 시도했지만 여전히 타이밍 문제)
+- 3-3. my.js 즉시 실행 결합도 → [이전 리뷰에서 확인하기](./2026040615_리뷰.md#3-3-mypage의-myjs--즉시-실행으로-인한-높은-결합도-중요도-높음)
+- 3-4. 폴더명 `(Auth)` 괄호 → [이전 리뷰에서 확인하기](./2026040615_리뷰.md#3-4-폴더명-auth--괄호는-피하는-게-좋아요-중요도-중간)
+- 3-5. SVG 아이콘 하드코딩 → [이전 리뷰에서 확인하기](./2026040615_리뷰.md#3-5-loginjs--registerjs--svg-아이콘이-html-문자열에-하드코딩-중요도-중간)
+- 3-6. login.js `==` 사용 → [이전 리뷰에서 확인하기](./2026040615_리뷰.md#3-6-loginjs에서--대신--사용-필요-중요도-중간)
+- 3-7. innerHTML XSS → [이전 리뷰에서 확인하기](./2026040615_리뷰.md#3-7-에러-메시지에-innerhtml-사용--xss-위험-중요도-중간)
+- 3-8. boardDetailUI XSS → [이전 리뷰에서 확인하기](./2026040615_리뷰.md#3-8-boarddetailuijs--사용자-데이터를-innerhtml에-직접-삽입-중요도-중간)
+- 3-9. HTML `<link>` 중복 → [이전 리뷰에서 확인하기](./2026040615_리뷰.md#3-9-html-조각에-link-태그가-계속-반복됨-중요도-중간)
+- 3-10. pokedexUI import 경로 → [이전 리뷰에서 확인하기](./2026040615_리뷰.md#3-10-pokedexuijs--import-경로-확장자-불일치-중요도-중간)
+- 3-11. `/public` 경로 문제 → [이전 리뷰에서 확인하기](./2026040615_리뷰.md#3-11-trainercardjs--이미지-경로에-public-포함-중요도-중간)
+- 3-12. mypage.html `<main>` 중첩 → [이전 리뷰에서 확인하기](./2026040615_리뷰.md#3-12-mypagehtml에-여전히-main-태그가-남아있음-중요도-중간)
+- 3-13. 빈 파일 pokemonApi.js → [이전 리뷰에서 확인하기](./2026040615_리뷰.md#3-13-빈-파일-srcapipokemonapijs-중요도-낮음) (이번에 `post.js`, `user.js`도 추가됨)
+- 3-14. base64 이미지 → [이전 리뷰에서 확인하기](./2026040615_리뷰.md#3-14-boarddetailjs에-base64-이미지-하드코딩-중요도-낮음)
+- 3-15. console.log 디버그 코드 → [이전 리뷰에서 확인하기](./2026040615_리뷰.md#3-15-consolelog-디버그-코드가-남아있음-중요도-낮음)
+- 3-16. window 전역 함수 → [이전 리뷰에서 확인하기](./2026040615_리뷰.md#3-16-pokedexuijs--window-전역-함수-사용-중요도-낮음)
+
+---
+
+## 1. 프로젝트 구조 살펴보기
+
+이전 리뷰와 동일합니다. 새로 추가된 파일만 표시합니다:
+
+```
+src/api/
+├── pokemonApi.js       ← 빈 파일 (이전부터)
+├── post.js             ← 빈 파일 (신규)
+└── user.js             ← 빈 파일 (신규)
+```
+
+---
+
+## 2. 잘한 점
+
+### API 연동을 직접 해냈어요!
+
+처음으로 백엔드 API와 연동하는 것은 정말 큰 도전이에요. 로그인, 회원가입, 포켓몬 등록/삭제까지 다양한 HTTP 메서드(GET, POST, DELETE)를 사용해 API를 연동한 것은 훌륭해요!
+
+```js
+// login.js — POST 요청으로 로그인 API 호출
+const res = await fetch(
+  `https://api.fullstackfamily.com/api/pocket-archive/v1/user/login`,
+  {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      loginId: login_id.value,
+      password: password.value,
+    }),
+  },
+);
+```
+
+### 인증(Authentication) 흐름 구현
+
+로그인 성공 시 토큰을 `localStorage`에 저장하고, 이후 API 요청에 `Authorization` 헤더로 전달하는 **토큰 기반 인증** 패턴을 잘 구현했어요. 이건 현업에서도 가장 많이 쓰는 방식이에요!
+
+```js
+// 로그인 성공 시 토큰 저장
+localStorage.setItem("token", result.data.token);
+
+// API 요청 시 토큰 전달
+headers: {
+  Authorization: `Bearer ${token}`,
+}
+```
+
+### 로그인 상태에 따른 UI 분기
+
+`header.js`에서 토큰 유무에 따라 로그인/로그아웃 버튼을 토글하는 것, `pokedexUI.js`에서 로그인 시에만 몬스터볼 북마크를 보여주는 것은 **사용자 경험(UX)**을 잘 고려한 설계예요.
+
+```js
+// header.js — 로그인 상태에 따라 다른 버튼 표시
+${isLoggedin
+  ? `<button class="logout-btn cursor-pointer" onclick="logout()">로그아웃</button>`
+  : `<button class="login-btn">로그인</button>`}
+```
+
+### 중복확인 후 버튼 활성화 패턴
+
+`register.js`에서 닉네임과 아이디 중복확인을 모두 통과해야 회원가입 버튼이 활성화되는 패턴은 사용자가 잘못된 정보로 가입하는 것을 미리 방지해주는 좋은 UX 설계예요.
+
+```js
+// 중복확인 결과에 따라 버튼 활성/비활성
+function updateButtonState() {
+  const signupBtn = document.getElementById("signupBtn");
+  if (validNickname === false && validId === false) {
+    signupBtn.disabled = false;
+  } else {
+    signupBtn.disabled = true;
+  }
+}
+```
+
+### 포켓몬 등록/삭제 즉시 반영
+
+`pokedex.js`에서 포켓몬을 등록/삭제한 후 `renderGrid(currentPage)`를 호출해서 화면을 즉시 업데이트하는 것은 **낙관적 UI(Optimistic UI)** 패턴이에요. 사용자가 결과를 바로 볼 수 있어서 반응성이 좋아요!
+
+```js
+window.poketmonReg = async function (event, id) {
+  event.stopPropagation();
+  await poketmonReg(id);
+  myPocketMons.push(id);
+  renderGrid(currentPage);  // ← 즉시 화면 갱신!
+};
+```
+
+---
+
+## 3. 개선하면 좋을 점
+
+### 3-1. boardDetail.js — const에 재할당 + 변수명 오류 (중요도: 높음 - 앱이 멈춰요!)
+
+**현재 상태:**
+
+```js
+// src/components/board/boardDetail.js 5~33번째 줄
+const postData = {};       // ← const로 선언
+const commentData = [];    // ← const로 선언
+try {
+  const postRes = await fetch(`.../${postId}`);         // ← postRes
+  const commentRes = await fetch(`.../${postId}/comments`);  // ← commentRes
+  // ...
+  postData = await res.json();       // ← 문제 1: const에 재할당 → TypeError!
+  commentData = await res.json();    // ← 문제 2: const에 재할당 → TypeError!
+                                     // ← 문제 3: res는 존재하지 않는 변수! (postRes, commentRes여야 해요)
+}
+```
+
+여기에 **3가지 문제**가 동시에 있어요:
+
+1. **`const`에 재할당** — `const`로 선언한 변수는 값을 바꿀 수 없어요. `let`으로 바꿔야 해요.
+2. **`res`는 존재하지 않는 변수** — `postRes`와 `commentRes`로 받았는데 `res.json()`을 호출하고 있어요.
+3. **같은 Response를 두 번 `.json()` 할 수 없어요** — 설령 변수명이 맞더라도, 하나의 Response에서 `.json()`은 한 번만 호출 가능해요.
+
+**왜 개선하면 좋을까?**
+
+이 코드가 실행되면 `TypeError: Assignment to constant variable` 에러가 발생하면서 게시글 상세 페이지가 완전히 멈춰요. 사용자는 하얀 화면만 보게 돼요.
+
+**추천:**
+
+```js
+let postData = {};
+let commentData = [];
+try {
+  const postRes = await fetch(`.../${postId}`);
+  const commentRes = await fetch(`.../${postId}/comments`);
+  if (!postRes.ok) throw new Error("게시물 불러오기 실패");
+  if (!commentRes.ok) throw new Error("댓글 불러오기 실패");
+
+  postData = await postRes.json();       // ← postRes.json()
+  commentData = await commentRes.json(); // ← commentRes.json()
+}
+```
+
+---
+
+### 3-2. boardDetail.js — setupCommentEvents에서 정의되지 않은 변수 사용 (중요도: 높음 - 앱이 멈춰요!)
+
+**현재 상태:**
+
+```js
+// src/components/board/boardDetail.js — setupCommentEvents 함수 안
+async function setupCommentEvents() {
+  // ...
+  submitBtn.onclick = async () => {
+    const res = await fetch(
+      `.../${commentId}/comments`,    // ← commentId가 어디에도 선언되지 않았어요!
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,  // ← token도 선언되지 않았어요!
+        },
+        body: {
+          content: text,               // ← JSON.stringify 빠졌어요!
+        },
+      },
+    );
+    commentData.push(data);            // ← commentData는 initPostDetail의 지역변수라 접근 불가!
+  };
+}
+```
+
+**4가지 문제**가 있어요:
+
+1. **`commentId` 미정의** — 이 함수 안에서 `commentId`를 선언하지 않았어요. `postId`를 사용하려 했을 것 같아요.
+2. **`token` 미정의** — `localStorage.getItem("token")`으로 가져와야 해요.
+3. **`body`에 `JSON.stringify` 누락** — `fetch`의 `body`에 객체를 직접 넣으면 `[object Object]`라는 문자열이 전송돼요.
+4. **`commentData` 접근 불가** — `initPostDetail` 함수 안의 지역변수라서 `setupCommentEvents`에서 접근할 수 없어요.
+
+**왜 개선하면 좋을까?**
+
+댓글 등록 버튼을 누르면 `ReferenceError`가 발생하고, 설령 에러가 안 나더라도 서버에 잘못된 데이터가 전송돼요. "결합도가 높다"는 것은 바로 이런 상황 — 한 함수가 다른 함수의 내부 변수에 의존하는 것이에요.
+
+**추천:**
+
+```js
+// initPostDetail에서 setupCommentEvents에 필요한 값을 인자로 전달 (결합도 낮추기!)
+setupCommentEvents(postId);
+
+// setupCommentEvents — 필요한 값을 직접 가져오거나 인자로 받기
+async function setupCommentEvents(postId) {
+  const submitBtn = document.getElementById("submitComment");
+  if (!submitBtn) return;
+
+  submitBtn.onclick = async () => {
+    const text = document.getElementById("commentInput").value;
+    if (!text.trim()) return alert("내용을 입력하세요");
+
+    const token = localStorage.getItem("token");  // ← 직접 가져오기
+    try {
+      const res = await fetch(
+        `https://api.fullstackfamily.com/api/pocket-archive/v1/posts/${postId}/comments`,
+        {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${token}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ content: text }),  // ← JSON.stringify!
+        },
+      );
+      if (!res.ok) throw new Error("댓글 등록 실패");
+      // 성공 시 페이지 새로고침 또는 댓글 목록 다시 불러오기
+    } catch (error) {
+      console.error(error);
+      alert("댓글 등록에 실패했어요.");
+    }
+    document.getElementById("commentInput").value = "";
+  };
+}
+```
+
+> **응집도와 결합도 핵심 포인트:** 함수가 외부 변수에 의존하면 결합도가 높아져요. 필요한 데이터는 **인자(parameter)**로 받거나 함수 안에서 직접 가져오면 결합도가 낮아져요.
+
+---
+
+### 3-3. register.js — 회원가입 요청의 body에 JSON.stringify 누락 (중요도: 높음 - 회원가입이 안 돼요!)
+
+**현재 상태:**
+
+```js
+// src/components/(Auth)/register.js — signupBtn 클릭 핸들러 안
+const res = await fetch(
+  `https://api.fullstackfamily.com/api/pocket-archive/v1/user/register`,
+  {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: {                       // ← JSON.stringify가 빠져있어요!
+      loginId: id.value,
+      nickname: nickname.value,
+      password: pwd.value,
+    },
+  },
+);
+const result = res.json();        // ← await도 빠져있어요!
+```
+
+**왜 개선하면 좋을까?**
+
+`fetch`의 `body`에 JavaScript 객체를 직접 넣으면, 브라우저가 자동으로 `.toString()`을 호출해서 `"[object Object]"`라는 문자열이 서버로 전송돼요. 서버는 이걸 파싱할 수 없어서 회원가입이 항상 실패해요.
+
+재미있는 건 `login.js`에서는 `JSON.stringify`를 올바르게 사용하고 있다는 거예요! 같은 패턴을 여기서도 적용하면 돼요.
+
+**추천:**
+
+```js
+const res = await fetch(
+  `https://api.fullstackfamily.com/api/pocket-archive/v1/user/register`,
+  {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({           // ← JSON.stringify 추가!
+      loginId: id.value,
+      nickname: nickname.value,
+      password: pwd.value,
+    }),
+  },
+);
+const result = await res.json();     // ← await 추가!
+```
+
+---
+
+### 3-4. pokedexUI.js — `import dotenv from "dotenv"` 브라우저에서 사용 불가 (중요도: 높음 - 빌드 에러!)
+
+**현재 상태:**
+
+```js
+// src/components/pokedex/pokedexUI.js 1번째 줄
+import dotenv from "dotenv";
+```
+
+**왜 개선하면 좋을까?**
+
+`dotenv`는 **Node.js(서버) 전용** 라이브러리예요. 브라우저에서는 `process.env`가 존재하지 않아요. 이 import가 있으면 Vite 빌드가 실패하거나 런타임 에러가 발생할 수 있어요.
+
+Vite에서 환경변수를 사용하려면 `.env` 파일에 `VITE_` 접두사를 붙인 변수를 선언하고, `import.meta.env.VITE_XXX`로 접근해요.
+
+**추천:**
+
+이 줄을 삭제하세요:
+
+```js
+// 삭제: import dotenv from "dotenv";
+```
+
+나중에 API URL을 환경변수로 관리하고 싶다면:
+
+```bash
+# .env 파일 (프로젝트 루트에 생성)
+VITE_API_URL=https://api.fullstackfamily.com/api/pocket-archive/v1
+```
+
+```js
+// JS에서 사용
+const API_URL = import.meta.env.VITE_API_URL;
+```
+
+---
+
+### 3-5. main.js — setTimeout(2ms)는 DOM 타이밍 문제를 해결하지 못해요 (중요도: 높음)
+
+**현재 상태:**
+
+```js
+// src/main.js — loadPage 함수 안
+setTimeout(() => {
+  if (page.includes('detailPost.html')) {
+    initPostDetail(postId || 2);
+  }
+}, 2);                                          // ← 2ms 후 실행
+document.getElementById('content').innerHTML = html;  // ← 이게 먼저 실행될 수도, 안 될 수도!
+```
+
+**왜 개선하면 좋을까?**
+
+`setTimeout(fn, 2)`는 "2ms 후에 실행해줘"라는 뜻인데, JavaScript의 이벤트 루프 특성상 2ms가 보장되지 않아요. 특히:
+- 브라우저가 바쁘면 2ms보다 훨씬 늦게 실행될 수 있어요 (이 경우 DOM이 있어서 동작)
+- 브라우저가 한가하면 HTML 삽입보다 먼저 실행될 수 있어요 (이 경우 DOM이 없어서 실패)
+
+이건 **경쟁 상태(Race Condition)**라고 해요 — "어떤 것이 먼저 끝나느냐"에 따라 결과가 달라지는 버그예요. 때로는 되고, 때로는 안 되니까 디버깅하기 가장 어려운 종류의 버그예요.
+
+**추천:**
+
+순서를 보장하면 돼요. **HTML을 먼저 넣고, 그 다음에 초기화**:
+
+```js
+// HTML을 먼저 넣기
+document.getElementById('content').innerHTML = html;
+
+// 그 다음에 초기화 (setTimeout 불필요!)
+if (page.includes('detailPost.html')) {
+  initPostDetail(postId || 2);
+}
+```
+
+---
+
+### 3-6. login.js — 사용자 비밀번호를 console.log로 출력 (중요도: 높음 - 보안 문제!)
+
+**현재 상태:**
+
+```js
+// src/components/(Auth)/login.js — checkStuff 함수 안
+console.log(login_id.value, password.value);   // ← 비밀번호가 콘솔에 찍혀요!
+
+// 로그인 성공 후
+console.log(res);
+console.log(result.data.token);                // ← 인증 토큰도 콘솔에 찍혀요!
+```
+
+**왜 개선하면 좋을까?**
+
+**비밀번호**와 **인증 토큰**은 절대 콘솔에 출력하면 안 되는 민감한 정보예요. 브라우저 개발자 도구를 열어둔 상태에서 누군가 어깨 너머로 보거나, 브라우저 확장 프로그램이 콘솔 출력을 수집할 수 있어요. 배포된 서비스에서 이런 코드가 남아있으면 보안 감사에서 반드시 지적돼요.
+
+**추천:**
+
+이 3줄을 모두 삭제하세요:
+
+```js
+// 삭제: console.log(login_id.value, password.value);
+// 삭제: console.log(res);
+// 삭제: console.log(result.data.token);
+```
+
+---
+
+### 3-7. API URL이 모든 파일에 하드코딩 (중요도: 중간 - 결합도 높음!)
+
+**현재 상태:**
+
+API URL `https://api.fullstackfamily.com/api/pocket-archive/v1`이 여러 파일에 반복되고 있어요:
+
+```js
+// login.js
+`https://api.fullstackfamily.com/api/pocket-archive/v1/user/login`
+
+// register.js (3곳)
+`https://api.fullstackfamily.com/api/pocket-archive/v1/user/check-nickname?...`
+`https://api.fullstackfamily.com/api/pocket-archive/v1/user/check-login-id?...`
+`https://api.fullstackfamily.com/api/pocket-archive/v1/user/register`
+
+// boardDetail.js (3곳)
+`https://api.fullstackfamily.com/api/pocket-archive/v1/posts/${postId}`
+`https://api.fullstackfamily.com/api/pocket-archive/v1/posts/${postId}/comments`
+`https://api.fullstackfamily.com/api/pocket-archive/v1/posts/${commentId}/comments`
+
+// pokedex.js (3곳)
+`https://api.fullstackfamily.com/api/pocket-archive/v1/pocketmons`
+`https://api.fullstackfamily.com/api/pocket-archive/v1/pocketmons`
+`https://api.fullstackfamily.com/api/pocket-archive/v1/pocketmons/${poketmonId}`
+```
+
+총 **10곳**에 같은 base URL이 반복돼요!
+
+**왜 개선하면 좋을까?**
+
+이것은 **결합도가 높은** 대표적인 패턴이에요. 만약 API URL이 바뀌면(예: 테스트 서버 → 운영 서버) 10곳을 모두 찾아서 수정해야 해요. 하나라도 빠뜨리면 일부 기능만 이상하게 동작하는 버그가 생겨요.
+
+**추천:**
+
+API base URL을 한 곳에서 관리하세요:
+
+```js
+// src/api/config.js (새 파일)
+export const API_BASE = "https://api.fullstackfamily.com/api/pocket-archive/v1";
+```
+
+```js
+// login.js
+import { API_BASE } from '../../api/config.js';
+
+const res = await fetch(`${API_BASE}/user/login`, { ... });
+```
+
+> **쉽게 말하면:** 전화번호를 수첩 10곳에 적어두면 번호가 바뀔 때 10곳 다 고쳐야 해요. 한 곳에만 적어두고 나머지는 "수첩 3페이지 보세요"라고 하면 1곳만 고치면 돼요. 이게 "결합도를 낮춘다"는 거예요!
+
+---
+
+### 3-8. pokedex.js — isLoggedIn이 모듈 로드 시 1번만 평가됨 (중요도: 중간)
+
+**현재 상태:**
+
+```js
+// src/components/pokedex/pokedex.js 8번째 줄
+const isLoggedIn = localStorage.getItem("token");  // ← 모듈이 처음 로드될 때 1번만 실행
+```
+
+**왜 개선하면 좋을까?**
+
+이 코드는 **모듈이 처음 import될 때 한 번만** 실행돼요. SPA(Single Page Application)에서 사용자가 로그인하거나 로그아웃해도 이 값은 바뀌지 않아요. 예를 들어:
+
+1. 비로그인 상태에서 도감 페이지 방문 → `isLoggedIn = null`
+2. 로그인 → localStorage에 토큰 저장됨
+3. 다시 도감 페이지 방문 → **여전히 `isLoggedIn = null`** (값이 안 바뀜!)
+
+`pokedexUI.js`에서는 `PokemonCard` 함수 안에서 매번 `localStorage.getItem("token")`을 호출하고 있어서 잘 동작해요. `pokedex.js`도 같은 패턴을 따르면 돼요.
+
+**추천:**
+
+```js
+// 모듈 최상단에서 제거
+// 삭제: const isLoggedIn = localStorage.getItem("token");
+
+// initPokedex 함수 안에서 매번 확인
+export async function initPokedex() {
+  const res = await fetch("/pokemon_full_ko.json");
+  allPokemon = await res.json();
+  filteredPokemon = [...allPokemon];
+
+  const isLoggedIn = localStorage.getItem("token");  // ← 함수 안에서!
+  if (isLoggedIn) {
+    myPocketMons = await loadPoketmons();
+  }
+  // ...
+}
+```
+
+---
+
+### 3-9. register.js — validNickname/validId 모듈 전역변수 + 빈 signup 함수 (중요도: 중간)
+
+**현재 상태:**
+
+```js
+// src/components/(Auth)/register.js — 모듈 최상단
+let validNickname = true;    // ← 모듈 전역
+let validId = true;          // ← 모듈 전역
+
+// ... 200줄 뒤에 ...
+async function signup() {}   // ← 빈 함수가 남아있어요!
+```
+
+**왜 개선하면 좋을까?**
+
+1. **모듈 전역변수** — SPA에서 회원가입 페이지를 여러 번 방문하면, 이전 방문의 중복확인 결과가 남아있어요. 닉네임만 바꿔도 이전에 확인한 아이디 결과가 유지돼서 혼란을 줄 수 있어요.
+2. **빈 `signup()` 함수** — 아무 동작도 하지 않는 빈 함수가 남아있어요. 실제 회원가입 로직은 `signupBtn` 이벤트 리스너 안에 있어서, 이 빈 함수는 혼동만 줘요.
+
+**추천:**
+
+```js
+// 1. 빈 signup() 함수 삭제
+// 삭제: async function signup() {}
+
+// 2. 전역변수를 initRegister 안으로 이동
+export function initRegister() {
+  let validNickname = true;    // ← 함수 안으로!
+  let validId = true;          // ← 함수 안으로!
+  // ...
+}
+```
+
+> **응집도 포인트:** 관련 있는 변수와 함수를 가까이 모아두면 응집도가 높아져요. `validNickname`은 `initRegister` 안에서만 쓰니까 그 안에 있는 게 자연스러워요.
+
+---
+
+### 3-10. register.js — 입력값 변경 시 중복확인 결과 초기화 안 됨 (중요도: 중간)
+
+**현재 상태:**
+
+중복확인을 한 후에 입력값을 바꿔도 이전 중복확인 결과가 그대로 유지돼요.
+
+```
+1. 닉네임 "포켓마스터" 입력 → 중복확인 클릭 → "사용 가능!" (validNickname = false)
+2. 닉네임을 "포켓몬짱"으로 변경 → (중복확인 안 함)
+3. 회원가입 버튼이 활성화 상태 → "포켓몬짱"은 중복확인 안 했는데 가입 가능!
+```
+
+**왜 개선하면 좋을까?**
+
+닉네임이나 아이디를 바꾸면 이전 중복확인은 무효예요. 다시 확인해야 해요. 이걸 안 하면 중복된 닉네임으로 가입 시도를 하게 되고 서버에서 에러가 나요.
+
+**추천:**
+
+입력값이 변경되면 중복확인 결과를 초기화하세요:
+
+```js
+nickname.addEventListener("input", () => {
+  validNickname = true;     // 초기화 (= 아직 확인 안 한 상태)
+  updateButtonState();      // 버튼 비활성화
+});
+
+id.addEventListener("input", () => {
+  validId = true;           // 초기화
+  updateButtonState();      // 버튼 비활성화
+});
+```
+
+---
+
+### 3-11. header.js — `window.logout`을 `window`에 직접 할당 (중요도: 중간)
+
+**현재 상태:**
+
+```js
+// src/components/header.js
+// HTML에서:
+onclick="logout()"
+
+// JS에서:
+window.logout = function () {
+  localStorage.removeItem("token");
+  location.reload();
+};
+```
+
+**왜 개선하면 좋을까?**
+
+이전 리뷰(3-16)에서 `window` 전역 함수 사용을 지적했는데, 같은 패턴이 계속 추가되고 있어요. `window`에 함수를 붙이면 **전역 공간이 오염**돼요.
+
+다른 라이브러리나 팀원이 만든 코드에서도 `logout`이라는 이름을 쓰면 서로 덮어씌워져요.
+
+**추천:**
+
+이벤트 위임 패턴을 사용하세요 (이미 login-btn에서 쓰고 있는 패턴이에요!):
+
+```js
+// header.js — 기존 이벤트 위임에 logout 추가
+document.addEventListener("click", (e) => {
+  if (e.target.classList.contains("login-btn")) {
+    history.pushState(null, "", "/login");
+    window.dispatchEvent(new PopStateEvent("popstate"));
+  }
+  if (e.target.classList.contains("logout-btn")) {
+    localStorage.removeItem("token");
+    location.reload();
+  }
+});
+```
+
+```js
+// HTML에서 onclick 제거
+`<button class="logout-btn cursor-pointer">로그아웃</button>`
+```
+
+---
+
+### 3-12. pokedex.js — loadPoketmons 에러 시 반환값 없음 (중요도: 중간)
+
+**현재 상태:**
+
+```js
+// src/components/pokedex/pokedex.js
+export async function loadPoketmons() {
+  const token = localStorage.getItem("token");
+  try {
+    // ... fetch ...
+    return result.data.myPocketmons;
+  } catch (error) {
+    console.error(error);
+    // ← return이 없어서 undefined가 반환돼요!
+  }
+}
+
+// 호출하는 곳
+myPocketMons = await loadPoketmons();  // ← 에러 시 undefined!
+// 이후 myPocketMons.includes(data.id) → TypeError: Cannot read property 'includes' of undefined
+```
+
+**왜 개선하면 좋을까?**
+
+서버 연결이 불안정하거나 토큰이 만료되면 `catch`로 빠지는데, 이때 반환값이 없어서 `myPocketMons`가 `undefined`가 돼요. 이후 `PokemonCard`에서 `myPocketMons.includes()`를 호출하면 에러가 나면서 도감 전체가 동작하지 않아요.
+
+**추천:**
+
+```js
+export async function loadPoketmons() {
+  const token = localStorage.getItem("token");
+  try {
+    // ... fetch ...
+    return result.data.myPocketmons;
+  } catch (error) {
+    console.error(error);
+    return [];  // ← 에러 시 빈 배열 반환 (안전하게!)
+  }
+}
+```
+
+---
+
+### 3-13. 빈 파일 src/api/post.js, src/api/user.js 추가 (중요도: 낮음)
+
+**현재 상태:**
+
+이전 리뷰에서 `src/api/pokemonApi.js`가 빈 파일이라고 지적했는데, 이번에 `post.js`와 `user.js`도 빈 파일로 추가되었어요.
+
+```
+src/api/
+├── pokemonApi.js   ← 빈 파일
+├── post.js         ← 빈 파일 (신규)
+└── user.js         ← 빈 파일 (신규)
+```
+
+**왜 개선하면 좋을까?**
+
+빈 파일이 3개나 있으면 "나중에 여기에 뭔가 넣을 거야"라는 의도는 알겠지만, 지금은 혼란만 줘요. 실제로 API 로직은 각 컴포넌트 파일(`login.js`, `register.js`, `pokedex.js` 등)에 직접 들어가 있어요.
+
+**추천 (2가지 중 택 1):**
+
+**방법 A:** 빈 파일 삭제 후, 필요할 때 생성
+
+**방법 B (추천!):** API 로직을 실제로 이 파일들로 옮기기 — 이러면 응집도가 높아져요!
+
+```js
+// src/api/user.js — 사용자 관련 API를 모아두기
+import { API_BASE } from './config.js';
+
+export async function login(loginId, password) { ... }
+export async function register(loginId, nickname, password) { ... }
+export async function checkNickname(nickname) { ... }
+export async function checkLoginId(loginId) { ... }
+```
+
+이러면 각 컴포넌트 파일은 UI만 담당하고, API 호출은 `src/api/` 폴더에 모이게 돼요 — **UI와 데이터 로직의 분리**! (boardDetail ↔ boardDetailUI 처럼요!)
+
+---
+
+## 4. 파일별 요약
+
+| 파일 | 완성도 | 주요 피드백 |
+|------|--------|-------------|
+| `src/components/(Auth)/login.js` | 75% | API 연동 잘 구현, 비밀번호 console.log 삭제 필요, `==` → `===` |
+| `src/components/(Auth)/register.js` | 55% | JSON.stringify 누락, await 누락, 빈 함수 정리 필요, 입력 변경 시 초기화 |
+| `src/components/board/boardDetail.js` | 30% | const 재할당, 변수명 오류(res), 미정의 변수 다수 — 즉시 수정 필요! |
+| `src/components/header.js` | 80% | 로그인/로그아웃 토글 잘 구현, window 전역 함수 대신 이벤트 위임 추천 |
+| `src/components/pokedex/pokedex.js` | 80% | 등록/삭제 잘 구현, isLoggedIn 타이밍, loadPoketmons 에러 처리 |
+| `src/components/pokedex/pokedexUI.js` | 70% | 몬스터볼 북마크 잘 구현, `import dotenv` 삭제 필요 |
+| `src/main.js` | 65% | postId 동적 전달 해결!, setTimeout 경쟁 상태 여전히 존재 |
+| `src/api/post.js` | 0% | 빈 파일 |
+| `src/api/user.js` | 0% | 빈 파일 |
+
+---
+
+## 5. 다음 단계 제안
+
+1. **boardDetail.js 긴급 수정** (3-1, 3-2) — const→let, res→postRes/commentRes, 미정의 변수 해결. 이거 안 고치면 게시글 상세가 완전히 안 돼요!
+2. **register.js JSON.stringify 추가** (3-3) — 1줄 추가로 회원가입 동작하게 만들기
+3. **pokedexUI.js `import dotenv` 삭제** (3-4) — 1줄 삭제로 빌드 에러 방지
+4. **main.js setTimeout 제거** (3-5) — HTML 삽입 순서만 바꾸면 됨
+5. **login.js 비밀번호 console.log 삭제** (3-6) — 3줄 삭제로 보안 문제 해결
+6. **API base URL 통합** (3-7) — config.js 파일 하나 만들어서 결합도 낮추기
+7. **기타 중간/낮음 항목** — 여유 있을 때 하나씩 개선
+
+---
+
+## 6. 마무리
+
+API 연동은 프론트엔드 개발에서 **가장 큰 전환점** 중 하나예요. 로그인, 회원가입, 포켓몬 등록/삭제까지 — 이전 리뷰에서 더미 데이터로만 되어 있던 기능들이 실제 서버와 연결되기 시작한 거예요. 이건 정말 큰 진전이에요!
+
+이번 리뷰의 핵심은:
+
+- **높음 항목들은 대부분 "오타" 수준** — `const` → `let`, `res` → `postRes`, `JSON.stringify` 추가 등. 로직은 맞는데 작은 실수들이에요. 실력이 부족한 게 아니라 코드 검증 습관이 아직 안 붙은 거예요.
+- **결합도 낮추기의 핵심** — 함수가 외부 변수에 의존하지 않고, 필요한 것을 **인자로 받거나** **직접 가져오도록** 만들기.
+- **API URL 중앙 관리** — 같은 문자열을 10곳에 복사하는 대신 한 곳에서 export하면 결합도가 확 낮아져요.
+
+boardDetail.js의 3가지 버그(3-1, 3-2)만 빨리 고치면, 프로젝트가 한 단계 더 올라갈 거예요. 화이팅!

--- a/reviews/2026040711_리뷰_해결.md
+++ b/reviews/2026040711_리뷰_해결.md
@@ -1,0 +1,787 @@
+# 리뷰 해결 가이드
+
+> 리뷰 날짜: 2026-04-07
+> 대상: 포켓아카이브 (Pocket Archive) — 포켓몬 도감과 커뮤니티 기능을 함께 제공하는 Vanilla JS 웹 서비스
+> 원본 리뷰: [2026040711_리뷰.md](./2026040711_리뷰.md)
+> 이전 해결 가이드: [2026040615_리뷰_해결.md](./2026040615_리뷰_해결.md)
+
+---
+
+## 3-1. boardDetail.js — const 재할당 + 변수명 오류 (중요도: 높음)
+
+### 문제
+
+`src/components/board/boardDetail.js` 5~33번째 줄에서 3가지 오류가 동시에 발생해요:
+1. `const`로 선언한 변수에 새 값을 넣으려고 함 (TypeError)
+2. `postRes`, `commentRes`로 받았는데 `res`라는 존재하지 않는 변수를 사용 (ReferenceError)
+3. 하나의 Response에서 `.json()`은 1번만 호출 가능
+
+### 해결 방법
+
+**Step 1.** `const`를 `let`으로 변경하고, 변수명을 올바르게 수정하세요.
+
+```js
+// 수정 전 (src/components/board/boardDetail.js 5~33번째 줄)
+const postData = {};
+const commentData = [];
+try {
+  const postRes = await fetch(
+    `https://api.fullstackfamily.com/api/pocket-archive/v1/posts/${postId}`,
+    { method: "GET" },
+  );
+  const commentRes = await fetch(
+    `https://api.fullstackfamily.com/api/pocket-archive/v1/posts/${postId}/comments`,
+    { method: "GET" },
+  );
+  if (!postRes.ok) {
+    throw new Error("게시물 불러오기 실패");
+  }
+  if (!commentRes.ok) {
+    throw new Error("게시물 불러오기 실패");
+  }
+
+  postData = await res.json();
+  commentData = await res.json();
+} catch (error) {
+  console.error(error);
+}
+
+// 수정 후
+let postData = {};
+let commentData = [];
+try {
+  const postRes = await fetch(
+    `https://api.fullstackfamily.com/api/pocket-archive/v1/posts/${postId}`,
+    { method: "GET" },
+  );
+  const commentRes = await fetch(
+    `https://api.fullstackfamily.com/api/pocket-archive/v1/posts/${postId}/comments`,
+    { method: "GET" },
+  );
+  if (!postRes.ok) {
+    throw new Error("게시물 불러오기 실패");
+  }
+  if (!commentRes.ok) {
+    throw new Error("댓글 불러오기 실패");
+  }
+
+  postData = await postRes.json();
+  commentData = await commentRes.json();
+} catch (error) {
+  console.error(error);
+}
+```
+
+> **쉽게 말하면:** `const`는 "이 상자에 다른 물건을 넣지 마세요"라는 라벨이에요. 상자 안 물건을 바꾸려면 `let`("바꿔도 돼요") 라벨을 붙여야 해요. 그리고 `res`는 아예 존재하지 않는 상자 이름이라 열려고 하면 에러가 나요.
+
+---
+
+## 3-2. boardDetail.js — setupCommentEvents 미정의 변수 (중요도: 높음)
+
+### 문제
+
+`src/components/board/boardDetail.js`의 `setupCommentEvents` 함수에서 `commentId`, `token`, `commentData`가 정의되지 않았고, `body`에 `JSON.stringify`가 빠져있어요.
+
+### 해결 방법
+
+**Step 1.** `initPostDetail`에서 `setupCommentEvents`에 `postId`를 전달하세요.
+
+```js
+// 수정 전 (initPostDetail 함수 마지막 줄)
+setupCommentEvents();
+
+// 수정 후
+setupCommentEvents(postId);
+```
+
+**Step 2.** `setupCommentEvents` 함수를 아래처럼 수정하세요.
+
+```js
+// 수정 전
+async function setupCommentEvents() {
+  const submitBtn = document.getElementById("submitComment");
+
+  if (submitBtn) {
+    submitBtn.onclick = async () => {
+      const text = document.getElementById("commentInput").value;
+      if (!text.trim()) {
+        return alert("내용을 입력하세요");
+      }
+      try {
+        const res = await fetch(
+          `https://api.fullstackfamily.com/api/pocket-archive/v1/posts/${commentId}/comments`,
+          {
+            method: "POST",
+            headers: {
+              Authorization: `Bearer ${token}`,
+              "Content-Type": "application/json",
+            },
+            body: {
+              content: text,
+            },
+          },
+        );
+        const data = await res.json();
+        commentData.push(data);
+      } catch (error) {
+        console.error(error);
+      }
+      document.getElementById("commentInput").value = "";
+    };
+  }
+}
+
+// 수정 후
+async function setupCommentEvents(postId) {
+  const submitBtn = document.getElementById("submitComment");
+  if (!submitBtn) return;
+
+  submitBtn.onclick = async () => {
+    const text = document.getElementById("commentInput").value;
+    if (!text.trim()) {
+      return alert("내용을 입력하세요");
+    }
+
+    const token = localStorage.getItem("token");
+    if (!token) {
+      return alert("로그인이 필요합니다.");
+    }
+
+    try {
+      const res = await fetch(
+        `https://api.fullstackfamily.com/api/pocket-archive/v1/posts/${postId}/comments`,
+        {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${token}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            content: text,
+          }),
+        },
+      );
+      if (!res.ok) throw new Error("댓글 등록 실패");
+
+      // 댓글 등록 성공 시 페이지 새로고침으로 최신 댓글 보여주기
+      // (나중에 여유가 되면 댓글 목록만 다시 불러오도록 개선할 수 있어요)
+      location.reload();
+    } catch (error) {
+      console.error(error);
+      alert("댓글 등록에 실패했어요.");
+    }
+    document.getElementById("commentInput").value = "";
+  };
+}
+```
+
+> **쉽게 말하면:** 함수에 필요한 재료(postId)를 밖에서 넣어주는 것이 "결합도를 낮추는" 핵심이에요. 함수가 알아서 냉장고(다른 함수의 지역변수)를 뒤지는 것보다, 필요한 재료를 레시피(인자)로 받는 게 훨씬 안전해요.
+
+---
+
+## 3-3. register.js — JSON.stringify 누락 + await 누락 (중요도: 높음)
+
+### 문제
+
+`src/components/(Auth)/register.js`의 회원가입 요청에서 `body`를 `JSON.stringify`로 감싸지 않았고, `res.json()`에 `await`가 빠져있어요.
+
+### 해결 방법
+
+**Step 1.** signupBtn 클릭 핸들러를 아래처럼 수정하세요.
+
+```js
+// 수정 전
+document
+  .getElementById("signupBtn")
+  .addEventListener("click", async function signup() {
+    try {
+      const res = await fetch(
+        `https://api.fullstackfamily.com/api/pocket-archive/v1/user/register`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: {
+            loginId: id.value,
+            nickname: nickname.value,
+            password: pwd.value,
+          },
+        },
+      );
+      const result = res.json();
+    } catch (error) {
+      console.error(error);
+    }
+  });
+
+// 수정 후
+document
+  .getElementById("signupBtn")
+  .addEventListener("click", async function () {
+    try {
+      const res = await fetch(
+        `https://api.fullstackfamily.com/api/pocket-archive/v1/user/register`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            loginId: id.value,
+            nickname: nickname.value,
+            password: pwd.value,
+          }),
+        },
+      );
+      if (!res.ok) throw new Error("회원가입 실패");
+
+      const result = await res.json();
+      alert("회원가입 성공! 로그인 페이지로 이동합니다.");
+      history.pushState(null, "", "/login");
+      window.dispatchEvent(new PopStateEvent("popstate"));
+    } catch (error) {
+      console.error(error);
+      alert("회원가입에 실패했어요. 다시 시도해주세요.");
+    }
+  });
+```
+
+> **쉽게 말하면:** `fetch`의 `body`에 물건을 보낼 때는 택배 상자(JSON.stringify)에 포장해야 해요. 포장 없이 보내면 받는 쪽(서버)에서 뭔지 알 수 없어요. `login.js`에서는 포장을 잘 했으니까, 같은 방법을 쓰면 돼요!
+
+---
+
+## 3-4. pokedexUI.js — `import dotenv` 삭제 (중요도: 높음)
+
+### 문제
+
+`src/components/pokedex/pokedexUI.js` 1번째 줄에 Node.js 전용 모듈 import가 있어요.
+
+### 해결 방법
+
+**Step 1.** 첫 번째 줄을 삭제하세요.
+
+```js
+// 수정 전 (src/components/pokedex/pokedexUI.js 1번째 줄)
+import dotenv from "dotenv";
+
+// 수정 후 (이 줄을 완전히 삭제)
+// (아무것도 없음 — 바로 TYPE_COLORS 시작)
+```
+
+**Step 2.** 만약 나중에 환경변수를 쓰고 싶다면, 프로젝트 루트에 `.env` 파일을 만드세요:
+
+```bash
+# .env (프로젝트 루트)
+VITE_API_URL=https://api.fullstackfamily.com/api/pocket-archive/v1
+```
+
+```js
+// JS에서 사용 (dotenv import 없이!)
+const apiUrl = import.meta.env.VITE_API_URL;
+```
+
+> **쉽게 말하면:** `dotenv`는 서버(Node.js)에서만 쓰는 도구예요. 브라우저에서는 Vite가 자동으로 `.env` 파일을 읽어주니까 `import.meta.env`만 쓰면 돼요. 마치 식당에서 직접 재료를 사 올 필요 없이 주방(Vite)에서 준비해주는 것처럼요!
+
+---
+
+## 3-5. main.js — setTimeout 제거하고 순서 변경 (중요도: 높음)
+
+### 문제
+
+`src/main.js`에서 `setTimeout(fn, 2)`와 `innerHTML` 할당의 순서가 잘못되어 경쟁 상태가 발생해요.
+
+### 해결 방법
+
+**Step 1.** `setTimeout`을 제거하고, `innerHTML` 할당 뒤에 초기화 함수를 호출하세요.
+
+```js
+// 수정 전 (src/main.js — loadPage 함수 안, 약 85~97번째 줄)
+    if (page.includes('pokedex.html')) {
+      initPokedex();
+    }
+    // if (page.includes("detailPost.html")) {
+    //   ...
+    // }
+    setTimeout(() => {
+      if (page.includes('detailPost.html')) {
+        initPostDetail(postId || 2);
+      }
+    }, 2);
+    document.getElementById('content').innerHTML = html;
+
+// 수정 후
+    // 1. HTML을 먼저 DOM에 넣기 (가장 중요!)
+    document.getElementById('content').innerHTML = html;
+
+    // 2. HTML이 DOM에 있으니까 이제 안전하게 초기화
+    if (page.includes('pokedex.html')) {
+      initPokedex();
+    }
+    if (page.includes('detailPost.html')) {
+      initPostDetail(postId || 2);
+    }
+```
+
+> **쉽게 말하면:** 집(HTML)을 짓기도 전에 가구(initPostDetail)를 배달하면, 가구 배달원이 "집이 없는데요?"라고 해요. `setTimeout(2ms)`는 "2밀리초 뒤에 다시 올게요"인데, 그 사이에 집이 지어질 수도 있고 아닐 수도 있어요. 확실한 방법은 **집을 먼저 짓고 가구를 배달**하는 거예요!
+
+---
+
+## 3-6. login.js — 비밀번호 console.log 삭제 (중요도: 높음)
+
+### 문제
+
+`src/components/(Auth)/login.js`의 `checkStuff` 함수에서 사용자 비밀번호와 인증 토큰이 콘솔에 출력돼요.
+
+### 해결 방법
+
+**Step 1.** 아래 3줄을 찾아서 삭제하세요.
+
+```js
+// 삭제할 줄들 (src/components/(Auth)/login.js — checkStuff 함수 안)
+
+// 1번째 삭제 (약 130번째 줄 부근)
+console.log(login_id.value, password.value);
+
+// 2번째 삭제 (약 145번째 줄 부근)
+console.log(res);
+
+// 3번째 삭제 (약 147번째 줄 부근)
+console.log(result.data.token);
+```
+
+> **쉽게 말하면:** 비밀번호를 화면에 쓰는 건 ATM 비밀번호를 소리 내어 말하는 것과 같아요. 개발 중에는 편하지만, 다른 사람이 볼 수 있는 상태에서는 절대 안 돼요. 디버깅이 끝나면 반드시 삭제!
+
+---
+
+## 3-7. API base URL 통합 (중요도: 중간)
+
+### 문제
+
+API URL `https://api.fullstackfamily.com/api/pocket-archive/v1`이 10곳에 중복되어 있어요.
+
+### 해결 방법
+
+**Step 1.** 새 파일 `src/api/config.js`를 만드세요.
+
+```js
+// src/api/config.js (새 파일)
+export const API_BASE = "https://api.fullstackfamily.com/api/pocket-archive/v1";
+```
+
+**Step 2.** 각 파일에서 import해서 사용하세요.
+
+```js
+// src/components/(Auth)/login.js — 파일 맨 위에 추가
+import { API_BASE } from '../../api/config.js';
+
+// 수정 전
+const res = await fetch(
+  `https://api.fullstackfamily.com/api/pocket-archive/v1/user/login`,
+  { ... }
+);
+
+// 수정 후
+const res = await fetch(
+  `${API_BASE}/user/login`,
+  { ... }
+);
+```
+
+```js
+// src/components/(Auth)/register.js — 파일 맨 위에 추가
+import { API_BASE } from '../../api/config.js';
+
+// 수정 전 (3곳 모두)
+`https://api.fullstackfamily.com/api/pocket-archive/v1/user/check-nickname?nickname=${nickname.value}`
+`https://api.fullstackfamily.com/api/pocket-archive/v1/user/check-login-id?loginId=${id.value}`
+`https://api.fullstackfamily.com/api/pocket-archive/v1/user/register`
+
+// 수정 후
+`${API_BASE}/user/check-nickname?nickname=${nickname.value}`
+`${API_BASE}/user/check-login-id?loginId=${id.value}`
+`${API_BASE}/user/register`
+```
+
+```js
+// src/components/board/boardDetail.js — 파일 맨 위에 추가
+import { API_BASE } from '../../api/config.js';
+
+// 수정 전
+`https://api.fullstackfamily.com/api/pocket-archive/v1/posts/${postId}`
+// 수정 후
+`${API_BASE}/posts/${postId}`
+```
+
+```js
+// src/components/pokedex/pokedex.js — 파일 맨 위에 추가
+import { API_BASE } from '../../api/config.js';
+
+// 수정 전 (3곳)
+`https://api.fullstackfamily.com/api/pocket-archive/v1/pocketmons`
+// 수정 후
+`${API_BASE}/pocketmons`
+```
+
+> **쉽게 말하면:** 친구 전화번호가 바뀌었을 때, 수첩 10곳에 적어둔 번호를 전부 고치는 것 vs 연락처 앱에서 1곳만 고치는 것. `config.js`가 연락처 앱이에요!
+
+---
+
+## 3-8. pokedex.js — isLoggedIn을 함수 안으로 이동 (중요도: 중간)
+
+### 문제
+
+`src/components/pokedex/pokedex.js` 8번째 줄의 `isLoggedIn`이 모듈 로드 시 한 번만 평가되어, 로그인/로그아웃 후에도 값이 안 바뀌어요.
+
+### 해결 방법
+
+**Step 1.** 모듈 최상단의 `const isLoggedIn` 줄을 삭제하세요.
+
+```js
+// 수정 전 (src/components/pokedex/pokedex.js 8번째 줄)
+const isLoggedIn = localStorage.getItem("token");
+
+// 수정 후 (이 줄 삭제)
+```
+
+**Step 2.** `initPokedex` 함수 안으로 옮기세요.
+
+```js
+// 수정 전
+export async function initPokedex() {
+  const res = await fetch("/pokemon_full_ko.json");
+  allPokemon = await res.json();
+  filteredPokemon = [...allPokemon];
+  if (isLoggedIn) {
+    myPocketMons = await loadPoketmons();
+  }
+  // ...
+}
+
+// 수정 후
+export async function initPokedex() {
+  const res = await fetch("/pokemon_full_ko.json");
+  allPokemon = await res.json();
+  filteredPokemon = [...allPokemon];
+
+  const isLoggedIn = localStorage.getItem("token");  // ← 여기로 이동!
+  if (isLoggedIn) {
+    myPocketMons = await loadPoketmons();
+  } else {
+    myPocketMons = [];  // 비로그인 시 빈 배열로 초기화
+  }
+  // ...
+}
+```
+
+> **쉽게 말하면:** 아침에 날씨를 확인하고 하루 종일 그 정보로 행동하면, 갑자기 비가 와도 우산을 안 챙겨요. 외출할 때마다(함수 실행마다) 날씨를 다시 확인하는 게 정확해요!
+
+---
+
+## 3-9. register.js — 전역변수 정리 + 빈 함수 삭제 (중요도: 중간)
+
+### 문제
+
+`src/components/(Auth)/register.js`에서 `validNickname`, `validId`가 모듈 전역에 선언되어 있고, 빈 `signup()` 함수가 남아있어요.
+
+### 해결 방법
+
+**Step 1.** 모듈 최상단의 전역변수를 삭제하세요.
+
+```js
+// 수정 전 (Register() 함수 닫는 중괄호 바로 아래)
+let validNickname = true;
+let validId = true;
+
+// 수정 후 (이 2줄 삭제)
+```
+
+**Step 2.** `initRegister` 함수 첫 줄에 추가하세요.
+
+```js
+// 수정 전
+export function initRegister() {
+  const pwd = document.getElementById("register_password");
+  // ...
+
+// 수정 후
+export function initRegister() {
+  let validNickname = true;    // ← 여기로 이동!
+  let validId = true;          // ← 여기로 이동!
+
+  const pwd = document.getElementById("register_password");
+  // ...
+```
+
+**Step 3.** `updateButtonState`도 `initRegister` 안으로 이동하세요.
+
+```js
+// 수정 전 (initRegister 함수 바깥에 있음)
+function updateButtonState() {
+  const signupBtn = document.getElementById("signupBtn");
+  if (validNickname === false && validId === false) {
+    signupBtn.disabled = false;
+  } else {
+    signupBtn.disabled = true;
+  }
+}
+
+// 수정 후 — initRegister 함수 안에 넣으세요 (중괄호 닫기 전에)
+  function updateButtonState() {
+    const signupBtn = document.getElementById("signupBtn");
+    if (validNickname === false && validId === false) {
+      signupBtn.disabled = false;
+    } else {
+      signupBtn.disabled = true;
+    }
+  }
+}  // ← initRegister의 닫는 중괄호
+```
+
+**Step 4.** 파일 맨 아래의 빈 `signup()` 함수를 삭제하세요.
+
+```js
+// 삭제
+async function signup() {}
+```
+
+> **쉽게 말하면:** 부엌에서만 쓰는 도구(validNickname)를 거실 테이블(모듈 전역)에 놓으면 다른 사람이 건드릴 수 있어요. 부엌 서랍(initRegister 안)에 넣으면 안전하고, 사용하는 곳과 가까워서 찾기도 쉬워요.
+
+---
+
+## 3-10. register.js — 입력 변경 시 중복확인 초기화 (중요도: 중간)
+
+### 문제
+
+닉네임이나 아이디를 중복확인한 후 입력값을 바꿔도 이전 결과가 유지돼요.
+
+### 해결 방법
+
+**Step 1.** `initRegister` 함수 안에 아래 코드를 추가하세요. (eye2 이벤트 리스너 뒤, registerForm submit 이벤트 리스너 전에 추가)
+
+```js
+  // 닉네임 입력 변경 시 중복확인 초기화
+  nickname.addEventListener("input", () => {
+    validNickname = true;
+    updateButtonState();
+  });
+
+  // 아이디 입력 변경 시 중복확인 초기화
+  id.addEventListener("input", () => {
+    validId = true;
+    updateButtonState();
+  });
+```
+
+> **쉽게 말하면:** 시험지에 이름을 쓰고 도장(중복확인)을 받았는데, 이름을 지우고 다시 쓰면 도장도 다시 받아야 해요. 이름이 바뀌면 도장은 무효!
+
+---
+
+## 3-11. header.js — window.logout을 이벤트 위임으로 변경 (중요도: 중간)
+
+### 문제
+
+`src/components/header.js`에서 `window.logout`을 전역 함수로 등록하고 HTML에서 `onclick="logout()"`으로 호출해요.
+
+### 해결 방법
+
+**Step 1.** HTML에서 `onclick` 속성을 제거하세요.
+
+```js
+// 수정 전 (Header 함수 안)
+${isLoggedin ? `<button class="logout-btn cursor-pointer" onclick="logout()">로그아웃</button>` : `<button class="login-btn" >로그인</button>`}
+
+// 수정 후
+${isLoggedin ? `<button class="logout-btn cursor-pointer">로그아웃</button>` : `<button class="login-btn">로그인</button>`}
+```
+
+**Step 2.** 기존 이벤트 위임에 logout 처리를 추가하세요.
+
+```js
+// 수정 전
+document.addEventListener("click", (e) => {
+  if (e.target.classList.contains("login-btn")) {
+    history.pushState(null, "", "/login");
+    window.dispatchEvent(new PopStateEvent("popstate"));
+  }
+});
+window.logout = function () {
+  localStorage.removeItem("token");
+  location.reload();
+};
+
+// 수정 후
+document.addEventListener("click", (e) => {
+  if (e.target.classList.contains("login-btn")) {
+    history.pushState(null, "", "/login");
+    window.dispatchEvent(new PopStateEvent("popstate"));
+  }
+  if (e.target.classList.contains("logout-btn")) {
+    localStorage.removeItem("token");
+    location.reload();
+  }
+});
+// window.logout 함수 삭제!
+```
+
+> **쉽게 말하면:** 회사에서 모든 전화를 교환원(document)이 받아서 해당 부서로 연결해주는 게 이벤트 위임이에요. 각 부서마다 따로 외부 전화번호(window 전역함수)를 가지는 것보다 깔끔하고 관리하기 쉬워요!
+
+---
+
+## 3-12. pokedex.js — loadPoketmons 에러 시 빈 배열 반환 (중요도: 중간)
+
+### 문제
+
+`src/components/pokedex/pokedex.js`의 `loadPoketmons` 함수가 에러 시 `undefined`를 반환해서 이후 코드에서 `TypeError`가 발생해요.
+
+### 해결 방법
+
+**Step 1.** `catch` 블록에 `return [];`을 추가하세요.
+
+```js
+// 수정 전
+export async function loadPoketmons() {
+  const token = localStorage.getItem("token");
+  try {
+    const res = await fetch(
+      `https://api.fullstackfamily.com/api/pocket-archive/v1/pocketmons`,
+      {
+        method: "GET",
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      },
+    );
+    if (!res.ok) {
+      throw new Error("불러오기 실패");
+    }
+    const result = await res.json();
+    return result.data.myPocketmons;
+  } catch (error) {
+    console.error(error);
+  }
+}
+
+// 수정 후 (마지막 줄만 추가!)
+export async function loadPoketmons() {
+  const token = localStorage.getItem("token");
+  try {
+    const res = await fetch(
+      `https://api.fullstackfamily.com/api/pocket-archive/v1/pocketmons`,
+      {
+        method: "GET",
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      },
+    );
+    if (!res.ok) {
+      throw new Error("불러오기 실패");
+    }
+    const result = await res.json();
+    return result.data.myPocketmons;
+  } catch (error) {
+    console.error(error);
+    return [];  // ← 이 한 줄 추가!
+  }
+}
+```
+
+> **쉽게 말하면:** 마트에 장을 보러 갔는데 문이 닫혀있어요(서버 에러). 그래도 빈 장바구니(빈 배열)를 들고 돌아와야 집에서 "장바구니 어디갔어?"(TypeError) 안 해요!
+
+---
+
+## 3-13. 빈 파일 정리 또는 활용 (중요도: 낮음)
+
+### 문제
+
+`src/api/` 폴더에 빈 파일 3개(`pokemonApi.js`, `post.js`, `user.js`)가 있어요.
+
+### 해결 방법
+
+**방법 A (간단):** 지금 사용하지 않으므로 3개 모두 삭제
+
+```bash
+# 터미널에서 실행
+rm src/api/pokemonApi.js src/api/post.js src/api/user.js
+```
+
+**방법 B (추천 — 3-7과 함께):** API 로직을 실제로 이 파일들에 구현하기
+
+```js
+// src/api/user.js — 사용자 관련 API 모음
+import { API_BASE } from './config.js';
+
+export async function login(loginId, password) {
+  const res = await fetch(`${API_BASE}/user/login`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ loginId, password }),
+  });
+  if (!res.ok) throw new Error("로그인 실패");
+  return res.json();
+}
+
+export async function register(loginId, nickname, password) {
+  const res = await fetch(`${API_BASE}/user/register`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ loginId, nickname, password }),
+  });
+  if (!res.ok) throw new Error("회원가입 실패");
+  return res.json();
+}
+
+export async function checkNickname(nickname) {
+  const res = await fetch(`${API_BASE}/user/check-nickname?nickname=${nickname}`);
+  const result = await res.json();
+  return result.data.exists;
+}
+
+export async function checkLoginId(loginId) {
+  const res = await fetch(`${API_BASE}/user/check-login-id?loginId=${loginId}`);
+  const result = await res.json();
+  return result.data.exists;
+}
+```
+
+이렇게 하면 `login.js`에서는:
+
+```js
+// src/components/(Auth)/login.js
+import { login } from '../../api/user.js';
+
+// 수정 전 (10줄)
+const res = await fetch(`https://...`, { method: "POST", ... });
+if (!res.ok) throw new Error("로그인 실패");
+const result = await res.json();
+localStorage.setItem("token", result.data.token);
+
+// 수정 후 (3줄!)
+const result = await login(login_id.value, password.value);
+localStorage.setItem("token", result.data.token);
+```
+
+> **쉽게 말하면:** 요리할 때 매번 재료부터 손질하는 것(fetch를 직접 호출) vs 미리 손질된 밀키트를 사용하는 것(api 함수 호출). 밀키트(api/user.js)를 만들어두면 요리(컴포넌트)가 훨씬 간단해져요!
+
+---
+
+## 수정 우선순위 체크리스트
+
+| 순서 | 항목 | 난이도 | 예상 시간 |
+|------|------|--------|-----------|
+| 1 | 3-4. pokedexUI.js `import dotenv` 삭제 | 쉬움 | 1분 |
+| 2 | 3-6. login.js console.log 삭제 (비밀번호 보안) | 쉬움 | 1분 |
+| 3 | 3-1. boardDetail.js const→let, res→postRes/commentRes | 쉬움 | 3분 |
+| 4 | 3-3. register.js JSON.stringify + await 추가 | 쉬움 | 2분 |
+| 5 | 3-5. main.js setTimeout 제거, HTML 삽입 순서 변경 | 쉬움 | 3분 |
+| 6 | 3-12. pokedex.js loadPoketmons return [] 추가 | 쉬움 | 1분 |
+| 7 | 3-2. boardDetail.js setupCommentEvents 수정 | 보통 | 10분 |
+| 8 | 3-8. pokedex.js isLoggedIn 위치 이동 | 쉬움 | 2분 |
+| 9 | 3-9. register.js 전역변수 정리 + 빈 함수 삭제 | 보통 | 5분 |
+| 10 | 3-10. register.js 입력 변경 시 중복확인 초기화 | 쉬움 | 3분 |
+| 11 | 3-11. header.js 이벤트 위임으로 변경 | 보통 | 5분 |
+| 12 | 3-7. API base URL 통합 (config.js) | 보통 | 15분 |
+| 13 | 3-13. 빈 파일 정리 또는 API 로직 분리 | 도전 | 30분 |
+
+> 순서 1~6번까지는 모두 "줄 삭제" 또는 "단어 추가" 수준의 간단한 수정이에요. 이것만 해도 **크래시(앱이 멈추는 버그) 6개가 한꺼번에 해결**돼요! 총 10분이면 충분해요. 순서대로 하나씩 해보세요. 화이팅!


### PR DESCRIPTION
## Summary
- API 연동 코드(로그인, 회원가입, 게시글 상세, 포켓몬 등록/삭제)에 대한 4차 증분 코드 리뷰
- **크래시 유발 버그 6건** 발견: boardDetail.js const 재할당, 변수명 오류, register.js JSON.stringify 누락 등
- **보안 이슈 1건**: login.js에서 비밀번호를 console.log로 출력
- **결합도 개선 제안**: API base URL 통합, 함수 인자로 데이터 전달, 모듈 전역변수 지역화
- 총 13개 개선 항목 (높음 6 / 중간 6 / 낮음 1)

## 리뷰 파일
- `reviews/2026040711_리뷰.md` — 코드 리뷰 본문
- `reviews/2026040711_리뷰_해결.md` — 수정 전/후 코드가 포함된 단계별 해결 가이드

## 주요 발견 사항

### 높음 (즉시 수정 필요)
| # | 파일 | 문제 |
|---|------|------|
| 3-1 | boardDetail.js | `const` 재할당 + `res` 미정의 변수 → TypeError |
| 3-2 | boardDetail.js | `commentId`, `token` 미정의 + JSON.stringify 누락 |
| 3-3 | register.js | 회원가입 `body`에 JSON.stringify 누락 → 서버 파싱 실패 |
| 3-4 | pokedexUI.js | `import dotenv` — Node.js 전용 모듈, 브라우저 에러 |
| 3-5 | main.js | `setTimeout(2ms)` 경쟁 상태 → DOM 없이 초기화 시도 |
| 3-6 | login.js | 비밀번호/토큰을 console.log로 출력 (보안 위험) |

### 중간 (안정성 개선)
| # | 파일 | 문제 |
|---|------|------|
| 3-7 | 전체 | API URL 10곳 하드코딩 → 결합도 높음 |
| 3-8 | pokedex.js | `isLoggedIn` 모듈 로드 시 1회만 평가 |
| 3-9 | register.js | 모듈 전역변수 + 빈 signup() 함수 |
| 3-10 | register.js | 입력 변경 시 중복확인 결과 미초기화 |
| 3-11 | header.js | `window.logout` 전역 함수 |
| 3-12 | pokedex.js | `loadPoketmons` 에러 시 undefined 반환 |

## Test plan
- [ ] 리뷰 문서 내 코드 블록의 파일명/줄 번호 정확성 확인
- [ ] 해결 가이드의 수정 전/후 코드가 실제 코드와 일치하는지 확인
- [ ] 이전 리뷰 미해결 항목 링크가 올바르게 연결되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)