### PR TITLE
docs: 4차 증분 코드 리뷰 및 해결 가이드 추가

### DIFF
--- a/docs/2026041410_리뷰.md
+++ b/docs/2026041410_리뷰.md
@@ -1,0 +1,560 @@
+# 프로젝트 코드 리뷰
+
+> 리뷰 날짜: 2026-04-14
+> 대상: 포켓아카이브 (Pocket Archive) — 4차 증분 리뷰
+> 이전 리뷰: [2026040811_리뷰.md](./2026040811_리뷰.md)
+
+---
+
+## 0. 이번 리뷰 범위
+
+이번 리뷰는 직전 develop 머지(`abd7e76`) 이후 추가 머지된 8개 커밋을 대상으로 합니다.
+
+**변경된 파일:**
+- `src/components/modal.js` — **신규!** 공통 알림 모달 컴포넌트 (`showModal`)
+- `src/components/board/boardDetail.js` — 댓글 수정/삭제, 좋아요, 게시글 삭제 기능
+- `src/components/board/boardDetailUI.js` — 트레이너 카드, 본인 게시글 수정/삭제 UI
+- `src/components/board/write.js` — 게시글 작성/수정, 파티 프리셋 연동, 이미지 업로드
+- `src/components/myparty/myparty.js` — 트레이너 카드 + 파티 프리셋 CRUD + 검색
+- `src/components/pokedex/pokedex.js` — API 캐시, 페이지네이션, 모달
+- `src/components/pokedex/pokedexUI.js` — 카드/페이지네이션/상세 모달 UI
+- `src/components/mypage/mypocketmon.js` — 마이페이지 내 포켓몬 목록 + 상세 모달
+- `src/components/mypage/mypocketmonUI.js` — 카드/레이아웃/빈 상태
+- `pages/mypage.html` — 로그아웃/탈퇴 모달, 포켓몬 상세 모달
+- `pages/pokedex.html` — 포켓몬 상세 모달
+
+**이전 리뷰 이후 잘 해결된 것 (정말 잘했어요!):**
+- ~~3차 리뷰 — 댓글/좋아요 CRUD~~ — boardDetail.js에서 잘 구현됨
+- ~~3차 리뷰 — 트레이너 카드 + 파티 CRUD~~ — myparty.js에서 잘 구현됨
+- ~~3차 리뷰 — `alert()` 사용~~ — `modal.js` 공통 컴포넌트 만들어서 일부 교체!
+- ~~3차 리뷰 — 포켓몬 데이터 캐싱~~ — `pokemonCache` Map 도입!
+
+새 모달 컴포넌트(`modal.js`)를 만든 건 정말 좋은 결정이에요. 이제 이걸 **모든 곳**에서 일관되게 쓰는 게 다음 단계입니다.
+
+---
+
+## 1. 한눈에 보는 핵심 요약
+
+| #     | 항목                                                                | 우선순위    | 카테고리   |
+| ----- | ------------------------------------------------------------------- | ----------- | ---------- |
+| 1-1   | `boardDetailUI.js` — `post.title`, `comment.content`에 `escapeHtml` 미적용 (XSS 위험) | 🔴 매우높음 | 보안       |
+| 1-2   | `boardDetail.js` — 인라인 `onclick="...(...)"` 안에 사용자 데이터 그대로 삽입 (XSS) | 🔴 매우높음 | 보안       |
+| 1-3   | `boardDetail.js` — `post`가 `null`인데 `post.preset` 접근 (런타임 에러)   | 🔴 매우높음 | 버그       |
+| 1-4   | `write.js` — 존재하지 않는 `errorData` 참조 (`throw new Error(errorData.message ...)`) | 🔴 매우높음 | 버그       |
+| 1-5   | `mypocketmon.js` & `pokedex.js` — `window.selectPokemon`, `window.poketmonDelete` **중복 등록** (페이지 이동 시 충돌) | 🟠 높음     | 결합도     |
+| 2-1   | `myparty.js` — 모듈 최상단 mutable 상태 12개 (재진입 시 잔존)           | 🟠 높음     | 응집도     |
+| 2-2   | `write.js` — 모듈 최상단에서 `localStorage.getItem("token")` (만료 토큰 잔존) | 🟠 높음     | 결합도     |
+| 2-3   | `myparty.js` — `openSaveModal()` 함수 정의되어 있지만 호출되지 않음 (dead code) | 🟡 보통     | 정리       |
+| 2-4   | `myparty.js` — `escapeHtml` import + 같은 이름 로컬 함수 충돌            | 🟡 보통     | 버그       |
+| 3-1   | `boardDetailUI.js` / `write.js` / `myparty.js` — `style="..."` 인라인 스타일 남발 | 🟠 높음     | 스타일     |
+| 3-2   | `pokedexUI.js` — `<style>` 태그를 `head`에 동적 주입, `setTimeout(0)` 후 DOM 접근 | 🟠 높음     | 스타일     |
+| 3-3   | `mypocketmonUI.js` — `<style>` 태그가 컴포넌트 안에 들어있음              | 🟡 보통     | 스타일     |
+| 4-1   | `pokedexUI.js` — 반환 문자열 안에 `<script>` 태그 삽입 (작동하지 않음)   | 🔴 매우높음 | 버그       |
+| 4-2   | `mypocketmon.js` — `PokemonModalContent`에 4번째 인자 `isBookmarked` 전달, 함수는 3개만 받음 | 🟡 보통     | 정리       |
+| 4-3   | `boardDetail.js` — `console.log(post, "post")` 디버그 출력 잔존        | 🟡 보통     | 정리       |
+| 4-4   | `write.js` — `console.log(selectedPreset, preset, loadPreset)` 외 디버그 출력 다수 | 🟡 보통     | 정리       |
+| 5-1   | `boardDetail.js` — `submitComment` / `setupLikeEvent`에서 `alert()` 사용 (모달 안 씀) | 🟡 보통     | 일관성     |
+| 5-2   | `write.js` — 검증 실패 시 `alert()` 사용                                  | 🟡 보통     | 일관성     |
+| 5-3   | `myparty.js` — `preset-modal`(HTML 직접) + `custom-modal`(모달 컴포넌트) **두 시스템 혼재** | 🟠 높음     | 응집도     |
+| 6-1   | `pages/mypage.html` — 로그아웃/탈퇴 모달이 거의 동일한 코드 반복           | 🟡 보통     | 응집도     |
+| 6-2   | `myparty.js` — 700줄 단일 파일에 상태/렌더/이벤트/CRUD/모달 모두 포함     | 🟡 보통     | 응집도     |
+
+---
+
+## 2. 응집도와 결합도, 한 번만 짚고 갈게요
+
+코드 리뷰를 보기 전에 **두 단어의 뜻**만 짧게 설명할게요. 이번 리뷰는 거의 다 이 두 가지 이야기예요.
+
+### 응집도 (Cohesion) — 한 파일 안의 코드들이 얼마나 "같은 일"을 하는가
+- **응집도가 높다** = 한 파일은 한 가지 일만 한다. (좋음 👍)
+- **응집도가 낮다** = 한 파일이 게시글 작성, 이미지 업로드, 모달 띄우기, 카테고리 변환, 토큰 관리... 다 한다. (나쁨 👎)
+- 응집도를 높이려면 → **파일/함수를 잘 쪼개기**.
+
+### 결합도 (Coupling) — 파일과 파일이 서로 얼마나 "서로를 알고" 있는가
+- **결합도가 낮다** = 파일끼리 `import`로만 약속된 함수 몇 개로만 연결됨. (좋음 👍)
+- **결합도가 높다** = `window.foo`, 전역 변수, 같은 `id` 공유, 한쪽이 바뀌면 다른 쪽도 동시에 망가짐. (나쁨 👎)
+- 결합도를 낮추려면 → **`window.*` 안 쓰기, `import`/`export`로만 연결**.
+
+> 이 두 가지를 머릿속에 두고 아래 리뷰를 읽으면 "왜 이렇게 고치라고 하지?"가 자연스럽게 이해될 거예요.
+
+---
+
+## 3. 자세한 리뷰
+
+### 🔴 1-1. `boardDetailUI.js` — 일부만 `escapeHtml`이 적용돼 있어요 (XSS 위험)
+
+`escapeHtml`을 적용한 부분과 안 한 부분이 섞여 있어요. **하나라도 빠지면 XSS는 막을 수 없어요.**
+
+📍 `src/components/board/boardDetailUI.js:120`
+
+```javascript
+<h1 class="text-3xl font-bold text-[#1a3a35] leading-tight flex-1">
+  ${post.title}                       // ❌ escapeHtml 안 함
+</h1>
+...
+<p ... class="...whitespace-pre-wrap">${comment.content}</p>  // ❌ 안 함
+```
+
+같은 파일 안에서 `post.nickname`, `post.content`는 `escapeHtml`을 적용했는데 정작 가장 눈에 띄는 **제목**과 **댓글 내용**은 빠져 있어요. 누가 `<script>alert(1)</script>` 같은 제목으로 게시글을 쓰면 그게 그대로 실행돼요.
+
+**왜 위험할까요?**
+- 누가 `"><img src=x onerror=alert(document.cookie)>` 같은 제목을 쓰면, 다른 사용자가 그 게시글에 들어갔을 때 그 사람의 쿠키가 공격자에게 전송돼요.
+- 댓글, 닉네임, 본문, 제목 — 사용자가 쓰는 모든 텍스트는 **항상** `escapeHtml`로 감싸야 해요.
+
+---
+
+### 🔴 1-2. `boardDetail.js` — 인라인 `onclick="..."` 안에 사용자 데이터를 그대로 넣었어요
+
+📍 `src/components/board/boardDetail.js:179-184`
+
+```javascript
+btnGroup.innerHTML = `
+  <button onclick="saveEditComment(${commentId}, '${originalContent}')" ...>저장</button>
+  <button onclick="cancelEditMode(${commentId}, '${originalContent}')" ...>취소</button>
+`;
+```
+
+`originalContent`(댓글 원문)을 `'...'`로 감싸서 onclick 속성 안에 넣었는데요, 만약 댓글에 작은 따옴표(`'`)가 들어 있으면:
+
+```html
+<!-- 댓글 내용이 "It's me" 라면 -->
+<button onclick="saveEditComment(1, 'It's me')">저장</button>
+                                       ↑ 여기서 문자열 깨짐 → 동작 안 함
+```
+
+작은 따옴표 정도면 그냥 안 동작하고 끝이지만, 누가 일부러 `');alert(1);//`을 댓글에 넣으면 JavaScript 실행이에요. **인라인 onclick에 사용자 데이터를 절대 넣지 마세요.**
+
+> `boardDetailUI.js`의 `onclick="handleDeleteComment(${comment.commentId})"`처럼 **숫자 ID만** 넣는 건 괜찮아요. 문자열이 위험한 거예요.
+
+---
+
+### 🔴 1-3. `boardDetail.js` — `post`가 `null`일 때 터지는 버그
+
+📍 `src/components/board/boardDetail.js:65-72`
+
+```javascript
+} catch (error) {
+  console.error(error);
+}                                          // ❌ post는 null인 채로 계속 진행
+const contentArea = document.getElementById("postDetailContent");
+const commentArea = document.getElementById("commentSection");
+
+if (contentArea) {
+  if (post.preset) {                       // 💥 post가 null이면 여기서 TypeError
+```
+
+`fetch`가 실패하면 `post`는 초기값인 `null`입니다. 그런데 그 다음에 `post.preset`을 바로 접근하니 콘솔에 에러가 떠요. 사용자에게는 "빈 페이지"만 보이고 무엇이 잘못됐는지도 안 보입니다.
+
+**왜 위험할까요?**
+- 네트워크가 잠깐 끊긴 사용자, 만료된 게시글에 들어간 사용자 = **모두 빈 화면**
+- 에러를 잡았으면 → 에러를 사용자에게 알려주거나 → 함수를 종료해야 해요.
+
+---
+
+### 🔴 1-4. `write.js` — 존재하지 않는 변수 `errorData` 참조
+
+📍 `src/components/board/write.js:281-283`
+
+```javascript
+if (!editRes.ok) {
+  throw new Error(errorData.message || "수정 실패");   // 💥 errorData가 어디에도 정의 안 됨
+}
+```
+
+`errorData` 변수는 함수 안에도 위에도 없어요. 수정 실패 시 이 줄을 만나면 **원래 보여주려던 "수정 실패" 메시지가 아니라 "errorData is not defined" ReferenceError**가 떠버립니다.
+
+이건 한 줄짜리 단순 버그지만, "에러를 처리하는 코드 자체가 에러를 내는 것"이라 디버깅이 정말 어려워져요.
+
+---
+
+### 🟠 1-5. `window.selectPokemon`, `window.poketmonDelete` 중복 등록
+
+`pokedex.js`와 `mypocketmon.js`가 **같은 이름**으로 `window` 함수를 등록해요.
+
+📍 `src/components/pokedex/pokedex.js:179, 271`
+```javascript
+window.selectPokemon = async function (no) { ... };
+window.poketmonDelete = async function (event, id) { ... };
+```
+
+📍 `src/components/mypage/mypocketmon.js:77`
+```javascript
+window.selectPokemon = async function (no) { ... };
+```
+
+📍 `src/components/myparty/myparty.js:671`
+```javascript
+window.poketmonDelete = async function (event, id) { ... };
+```
+
+**문제는?**
+- 사용자가 도감 → 마이페이지 → 도감 순서로 이동하면, 도감의 `selectPokemon`이 마이페이지 버전으로 **덮어써져 있어요**.
+- 도감에서 포켓몬을 클릭했는데 마이페이지 모달 로직이 뜨거나, 마이페이지에 없는 포켓몬을 찾으려다 에러가 나거나 — 원인을 찾기 정말 힘들어요.
+- `myparty.js`의 `poketmonDelete`는 마이파티 화면용인데, 도감 화면에서 ★ 버튼을 누르면 마이파티 함수가 실행될 수도 있어요.
+
+**핵심 메시지:** `window.foo = ...`는 **결합도가 가장 높은 코드**예요. 한 파일이 다른 파일의 동작을 모르는 사이에 망가뜨려요.
+
+---
+
+### 🟠 2-1. `myparty.js` — 모듈 최상단의 mutable 상태 12개
+
+📍 `src/components/myparty/myparty.js:7-22`
+
+```javascript
+let selectedSlot = null;
+let party = Array(6).fill(null);
+let gender = "man";
+let loadedPresetIndex = null;
+
+let root = null;
+let listEl = null;
+let countEl = null;
+let presetListEl = null;
+let presetCountEl = null;
+
+let pokemons = [];
+let presets = [];
+let koNameMap = {};
+let searchQuery = "";
+```
+
+이 변수들은 **JS 모듈이 한 번 로드되면 끝까지 메모리에 살아 있어요**. 사용자가 마이페이지의 마이파티 탭에 들어갔다 나갔다 다시 들어오면, 이전 상태가 그대로 남아 있어요.
+
+- 이전 검색어가 그대로 살아 있고
+- 이전에 선택했던 슬롯이 살아 있고
+- 다른 사용자로 로그인을 다시 했어도 이전 사용자의 `pokemons`가 살아 있어요.
+
+**응집도 측면:** "나의 파티" 화면이라는 한 가지 일을 하는 건 맞지만, 한 파일이 12개의 상태를 동시에 관리하면 **어떤 상태가 어떤 함수랑 연결돼 있는지** 추적이 안 돼요.
+
+---
+
+### 🟠 2-2. `write.js` — 모듈 최상단에서 `localStorage.getItem("token")`
+
+📍 `src/components/board/write.js:17`
+
+```javascript
+let uploadImgUrl = "";
+const token = localStorage.getItem("token");   // ❌ 모듈 로드 시점에 한 번만 평가됨
+let loadPreset = [];
+```
+
+이 모듈이 처음 import되는 순간 `token`이 한 번 박혀요. 그 다음에 사용자가 **로그아웃했다가 다른 계정으로 로그인**해도, 이 `token`은 첫 사용자 토큰 그대로 남습니다.
+
+다행히 함수 안쪽(`submitPost`, `initWrite`)에서는 `localStorage.getItem("token")`을 다시 부르고 있어요. 그런데 313라인의 이미지 업로드는 **모듈 최상단의 `token`을 사용**합니다:
+
+```javascript
+const uploadRes = await fetch(`${BASE_URL}/images`, {
+  method: "POST",
+  headers: { Authorization: `Bearer ${token}` },   // ⚠️ 위에서 박힌 토큰
+  ...
+});
+```
+
+> 일관성이 깨지면 "왜 어떨 땐 되고 어떨 땐 안 되지?" 라는 가장 답답한 버그가 생겨요.
+
+---
+
+### 🟡 2-3. `myparty.js` — `openSaveModal()` 함수가 호출되지 않아요 (dead code)
+
+📍 `src/components/myparty/myparty.js:349-417`
+
+`openSaveModal` 함수가 67줄에 걸쳐 정의되어 있는데, 파일 어디에서도 호출하는 곳이 없어요. `bindActionButtons`의 `saveBtn` 클릭 핸들러는 `openOverwriteModal()` 또는 `openNewSaveModal()`을 부르거든요.
+
+**왜 정리해야 할까요?**
+- 다음에 다른 사람이 이 파일을 읽을 때 "어, 이 함수는 어디서 부르지?" 하고 헤매요.
+- 죽은 코드는 빌드 결과물 크기만 늘려요.
+- 미래의 본인이 봤을 때 "여기에 추가하면 되겠다" 하고 잘못 고칠 수 있어요.
+
+---
+
+### 🟡 2-4. `myparty.js` — `escapeHtml` 이름 충돌
+
+📍 `src/components/myparty/myparty.js:529, 663-667`
+
+```javascript
+// 529줄
+${escapeHtml(preset.name)}      // 이때 어느 escapeHtml이 불릴까요?
+
+// 663~667줄
+function escapeHtml(text) {
+  const div = document.createElement("div");
+  div.textContent = text;
+  return div.innerHTML;
+}
+```
+
+파일 상단에는 `import { escapeHtml }` 이 없는데, 같은 이름의 로컬 함수가 정의돼 있어요. 다행히 지금은 로컬 함수만 있으니 동작하지만:
+
+1. 누가 나중에 `import { escapeHtml } from "../../utils/escapeHtml.js"` 를 추가하면 **이름 충돌로 에러**가 납니다.
+2. 같은 기능의 함수가 `utils/escapeHtml.js`에 이미 있는데, 또 만들고 있어요. **DRY 원칙 위반** (Don't Repeat Yourself).
+
+---
+
+### 🟠 3-1. `style="..."` 인라인 스타일 남발 — Tailwind를 안 쓰고 있어요
+
+이 프로젝트는 **Tailwind CSS를 쓰기로 한 프로젝트**예요. 그런데 새로 추가된 코드들은 다시 인라인 `style="..."`로 돌아갔습니다.
+
+📍 `src/components/board/boardDetailUI.js:60-91`
+```html
+<div style="width: 100%; max-width: 600px; margin: 24px auto;">
+  <div style="position: relative; width: 100%; border-radius: 12px; overflow: hidden;">
+    ...
+    <div style="position: absolute; top: ${pos.top}; left: ${pos.left}; width: 20%; height: 17%;">
+```
+
+📍 `src/components/myparty/myparty.js:507-516`
+```html
+<button ... style="width:100%; padding:10px; border-radius:12px; border:1.5px dashed #d1d5db;
+                   background:#f8fafc; color:#9ca3af; font-size:13px; font-weight:600;
+                   cursor:pointer; transition:all 0.15s; text-align:center;
+                   ${isLoaded ? 'outline:2px solid #5eead4; outline-offset:1px;' : ''}"
+        onmouseover="this.style.borderColor='#5eead4'; this.style.color='#0d9488'; ..."
+        onmouseout="this.style.borderColor='#d1d5db'; ...">
+```
+
+**왜 문제일까요?**
+1. **응집도 ↓**: 어떤 스타일이 어디 있는지 찾기 힘들어요. CSS 클래스 이름으로 검색하면 한 곳, 인라인 스타일은 매번 새로 정의해야 해요.
+2. **재사용 불가**: 같은 디자인 카드를 다른 곳에서도 쓰려면 또 복붙해야 해요.
+3. **반응형 안 됨**: `style="..."`은 미디어쿼리 못 써요. Tailwind는 `md:` `lg:` 같은 prefix로 한 줄에 끝나요.
+4. **호버 안 됨**: `style="..."`은 `:hover` 못 써요. 그래서 `onmouseover`로 다시 우회하고 있어요. 이건 **인라인 onclick과 똑같이 위험한 패턴**이에요.
+
+---
+
+### 🟠 3-2. `pokedexUI.js` — `<style>` 동적 주입 + `setTimeout(0)` 후 DOM 접근
+
+📍 `src/components/pokedex/pokedexUI.js:259-381`
+
+```javascript
+// 스타일 head에 한 번만 쳐넣기.......
+if (!document.getElementById("pm-modal-styles")) {
+  const style = document.createElement("style");
+  style.id = "pm-modal-styles";
+  style.textContent = `
+    @media (min-width: 790px) {
+      .pm-bottom-grid   { display: grid !important; }
+      ...
+    }
+  `;
+  document.head.appendChild(style);
+}
+
+let pmIdx = 0;
+const PM_TOTAL = 6;
+
+setTimeout(() => {
+  const inner = document.getElementById("pmSliderInner");
+  const prev = document.getElementById("pmPrev");
+  const next = document.getElementById("pmNext");
+  if (!inner || !prev || !next) return;
+  ...
+}, 0);
+```
+
+여기엔 세 가지 문제가 한꺼번에 있어요:
+
+1. **CSS를 JS로 주입하면 안 돼요.** 이 프로젝트는 Tailwind를 쓰니까, `pm-bottom-grid`, `pm-bottom-slider` 같은 클래스 대신 `hidden md:grid`, `flex md:hidden`을 그대로 쓰면 됩니다.
+2. **`setTimeout(0)` 후 DOM을 찾는 패턴**: 이 함수는 HTML 문자열을 **반환만** 해요. 그런데 setTimeout 안에서 그 반환 결과물에 있는 `pmSliderInner`를 찾아요. 작동하긴 하지만 "이 코드가 호출자가 반환값을 어디에 넣었는지" 가정하고 있어요. 즉 **결합도 폭발**.
+3. **`!important` 남발**: Tailwind를 쓰면 거의 필요 없어요. Tailwind는 충돌이 잘 안 일어나도록 설계돼 있어요.
+
+---
+
+### 🟡 3-3. `mypocketmonUI.js` — `<style>` 태그가 컴포넌트 안에 들어있어요
+
+📍 `src/components/mypage/mypocketmonUI.js:62-74`
+
+```javascript
+return `
+  <div class="bg-white rounded-2xl" style="padding: 24px;">
+    ...
+    <style>
+      #my-pokemon-grid { display: grid; ... }
+      @media (min-width: 461px)  { #my-pokemon-grid { grid-template-columns: repeat(2, ...); } }
+      @media (min-width: 672px)  { #my-pokemon-grid { grid-template-columns: repeat(3, ...); } }
+      ...
+    </style>
+    <div id="my-pokemon-grid"></div>
+  </div>
+`;
+```
+
+좋은 점: 컴포넌트가 자기 스타일을 같이 들고 있다는 발상은 좋아요 (관심사가 모여 있음).
+나쁜 점: HTML 안에 `<style>` 태그를 넣으면 **이 컴포넌트가 여러 번 렌더링될 때마다 같은 스타일이 또 들어가요**. 그리고 다른 곳에서 같은 `id`를 쓰면 영향을 줘요.
+
+→ Tailwind의 `grid-cols-1 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4` 한 줄로 끝나는 일이에요.
+
+---
+
+### 🔴 4-1. `pokedexUI.js` — 반환 문자열 안의 `<script>` 태그는 실행되지 않아요!
+
+📍 `src/components/pokedex/pokedexUI.js:565-585`
+
+```javascript
+return `
+  <div class="pm-modal-wrap" ...>
+    ...
+  </div>
+
+  <script>
+    (function() {
+      let idx = 0;
+      const TOTAL = 6;
+      window.pmSlide = function(dir) { ... };
+    })();
+  <\/script>
+`;
+```
+
+이 부분은 **innerHTML로 들어가요**. 그런데 **`innerHTML`로 삽입한 `<script>` 태그는 브라우저가 실행하지 않아요**. 보안상 명세에 그렇게 되어 있습니다.
+
+즉:
+- 위쪽의 `setTimeout(0)` 안에서 등록한 핸들러는 동작하고
+- 아래쪽의 `<script>` 안에 만든 `window.pmSlide`는 절대 등록되지 않습니다.
+
+다행히 슬라이더는 `setTimeout` 쪽 코드로 동작하긴 해요. 그래서 이 `<script>` 블록은 **있어도 그만 없어도 그만, 의미 없는 코드**예요. 깨끗이 지워야 해요.
+
+---
+
+### 🟡 4-2. `mypocketmon.js` — `PokemonModalContent` 시그니처 불일치
+
+📍 `src/components/mypage/mypocketmon.js:103-109`
+
+```javascript
+const isBookmarked = myPocketmons.includes(no);
+content.innerHTML = PokemonModalContent(
+  data,
+  p.name,
+  species,
+  isBookmarked,                    // ❌ 4번째 인자
+);
+```
+
+📍 `src/components/pokedex/pokedexUI.js:209`
+
+```javascript
+export const PokemonModalContent = (data, koName, species) => {   // 인자 3개만 받음
+```
+
+`isBookmarked`는 **그냥 버려져요**. 함수 시그니처가 안 맞아도 JS는 에러를 안 내요. 그래서 "북마크 상태가 모달에 안 보이네?" 하고 한참 디버깅하게 돼요.
+
+→ **둘 중 하나로 통일.** 모달이 북마크 상태를 표시할 거면 함수 시그니처를 4개로 늘리고, 안 쓸 거면 호출 쪽에서 빼야 해요.
+
+---
+
+### 🟡 4-3 & 4-4. 디버그 `console.log`가 살아 있어요
+
+📍 `src/components/board/boardDetail.js:63`
+```javascript
+post = postJson.data;
+console.log(post, "post");                   // ❌
+```
+
+📍 `src/components/board/write.js:25, 46, 216, 225, 248`
+```javascript
+console.log(selectedPreset, preset, loadPreset);
+console.log(response.data);                   // 참고로 fetch 응답엔 .data가 없어요
+console.log(postData, "load");
+console.log(option.value);
+console.log("default");
+```
+
+`console.log`는 개발할 때만 쓰는 메모예요. 프로덕션에선:
+- 사용자 브라우저 콘솔에 정보가 노출돼요 (게시글 데이터, 토큰, 사용자 정보 등).
+- 다른 사람이 코드를 읽을 때 "이게 중요한 로깅인가?" 헷갈려요.
+
+PR 만들기 전에 항상 `git diff` 로 한 번 훑고 console.log를 지우세요.
+
+---
+
+### 🟡 5-1 & 5-2. 새로 만든 모달을 안 쓰고 `alert()`을 또 쓰고 있어요
+
+📍 `src/components/board/boardDetail.js:97-98, 131`
+```javascript
+if (!text.trim()) {
+  return alert("내용을 입력하세요");                  // ❌
+}
+...
+if (!userToken) return alert("로그인이 필요한 서비스입니다.");   // ❌
+```
+
+📍 `src/components/board/write.js:242-244, 299-301, 310`
+```javascript
+if (!title) return alert("제목을 입력해주세요.");
+if (!selectedCategory) return alert("카테고리를 선택해주세요.");
+if (!content) return alert("내용을 입력해주세요.");
+...
+alert("게시글 작성 중 오류가 발생했습니다.");
+```
+
+`modal.js`의 `showModal`을 만들었는데 정작 게시글 화면에서는 안 쓰고 있어요. **새로 만든 좋은 도구를 본인이 안 쓰면, 다음 사람도 안 써요.** 일관성 있게 다 바꿔야 해요.
+
+---
+
+### 🟠 5-3. `myparty.js` — 모달 시스템이 두 개나 있어요
+
+`myparty.js`는 두 가지 다른 모달을 동시에 써요:
+
+1. **`modal.js`의 `showModal`** — `import { showModal } from "../modal.js"`로 가져와서 알림용으로 씀
+2. **`preset-modal`** — `myparty.html` 안에 직접 박혀 있는 입력 가능한 모달, `openOverwriteModal` / `openNewSaveModal`에서 직접 DOM 조작
+
+같은 화면에서 두 가지 다른 모달 디자인이 떠요. 사용자 입장에선 "왜 어떨 땐 모양이 다르지?" 합니다.
+
+**왜 이렇게 됐을까요?** `modal.js`는 알림(확인 버튼 1개)만 지원해요. 입력 박스 + 확인/취소 2개 버튼이 필요한 경우는 `modal.js`에 없으니 직접 만든 거죠.
+
+→ `modal.js`를 **확장 가능**하게 만들어서 한 곳에서 관리해야 해요. 자세한 건 해결 가이드에 적었어요.
+
+---
+
+### 🟡 6-1. `pages/mypage.html` — 로그아웃/탈퇴 모달이 거의 동일
+
+📍 `pages/mypage.html:31-96`
+
+`logout-modal`과 `withdraw-modal`이 거의 똑같은 HTML 구조를 두 번 반복하고 있어요. 한 군데서 디자인을 바꾸면 다른 한 곳도 똑같이 바꿔야 해요. 이건 응집도가 아니라 **반복(중복)** 입니다.
+
+→ **확장된 `modal.js`가 모든 모달을 책임지면** 이 두 블록을 HTML에서 통째로 지울 수 있어요.
+
+---
+
+### 🟡 6-2. `myparty.js` — 700줄 단일 파일
+
+이 파일 안에 있는 것:
+- 12개의 모듈 상태
+- 6개의 fetch 호출 (loadBookmarkedPokemons, loadPartyPresets, savePreset, updatePreset, deletePreset, fetchPokemonsByIds)
+- 4개의 렌더 함수 (renderTrainerCard, renderList, renderPresets, ...)
+- 2가지 모달 함수 (openOverwriteModal, openNewSaveModal)
+- 1개의 죽은 함수 (openSaveModal)
+- 직접 만든 escapeHtml
+- window.poketmonDelete 등록
+
+이걸 **한 사람이** 읽고 이해하고 수정하기는 너무 힘들어요. 응집도가 낮은 거예요. "마이파티 화면" 한 가지 일을 하긴 하지만, 한 가지 일이 너무 크면 **그 안에서 또 쪼개야** 해요.
+
+쪼개는 방법은 해결 가이드에 단계별로 적어둘게요.
+
+---
+
+## 4. 칭찬 코너 ✨
+
+- ✅ `modal.js`로 공통 모달을 만들기 시작한 것 — 정말 잘했어요!
+- ✅ `pokemonCache` Map으로 PokeAPI 요청 줄인 것 — 성능 의식이 있어요.
+- ✅ `boardDetail.js`에서 인증 토큰을 함수 안에서 다시 가져오는 것 — `write.js`도 이렇게 가야 해요.
+- ✅ `boardDetailUI.js`에서 `post.nickname`, `post.content`, `categoryMap[post.category]`에 `escapeHtml` 적용 — 거의 다 왔어요. 제목과 댓글만 마저 적용하면 돼요.
+- ✅ `mypocketmon.js`의 `Promise.all`로 병렬 로딩 — 좋은 패턴이에요.
+- ✅ 카테고리 매핑 (`categoryMap`, `reverseCategoryMap`) — 영문 enum과 한국어 표시를 분리한 것은 좋아요.
+
+---
+
+## 5. 우선순위 요약
+
+> 시간이 없으면 위에서부터 순서대로 고치세요.
+
+1. 🔴 **1-3, 1-4** — 단순 버그. 5분이면 고침. 사용자에게 즉시 영향.
+2. 🔴 **1-1, 1-2** — XSS 보안. `escapeHtml` 일관성 + 인라인 onclick 제거.
+3. 🔴 **4-1** — 의미 없는 `<script>` 블록 삭제.
+4. 🟠 **1-5** — `window.*` 중복 등록 제거 → 이벤트 위임으로 전환.
+5. 🟠 **5-3** — `modal.js` 확장 → 입력 모달 지원하도록 → `myparty.js`/`mypage.html` 모달 통일.
+6. 🟠 **2-2, 2-1** — 토큰/상태를 함수 안에서 매번 새로.
+7. 🟠 **3-1, 3-2** — 인라인 스타일 → Tailwind.
+8. 🟡 **나머지** — 정리 & 일관성.
+
+다음 리뷰까지 1-3, 1-4, 4-1만 먼저 잡아도 안정성이 크게 올라가요. 화이팅! 🔥
+
+해결 방법은 [2026041410_리뷰_해결.md](./2026041410_리뷰_해결.md)에서 자세히 다룹니다.

--- a/docs/2026041410_리뷰_해결.md
+++ b/docs/2026041410_리뷰_해결.md
@@ -1,0 +1,1073 @@
+# 코드 리뷰 해결 가이드
+
+> 작성 날짜: 2026-04-14
+> 대상 리뷰: [2026041410_리뷰.md](./2026041410_리뷰.md)
+
+이 문서는 리뷰에서 지적된 항목들을 **하나씩 어떻게 고치는지** 단계별로 보여줘요. 그냥 정답만 보여주는 게 아니라, **왜 이렇게 고치는지**도 같이 설명할게요.
+
+## 목차
+
+1. [🔴 매우높음 — 즉시 수정](#1-매우높음--즉시-수정)
+2. [🟠 높음 — 응집도/결합도 정리](#2-높음--응집도결합도-정리)
+3. [🟠 높음 — Tailwind로 스타일 정리](#3-높음--tailwind로-스타일-정리)
+4. [🟡 보통 — 정리 & 일관성](#4-보통--정리--일관성)
+5. [💎 보너스: 작은 리팩터링 패턴](#5-보너스-작은-리팩터링-패턴)
+
+---
+
+## 1. 🔴 매우높음 — 즉시 수정
+
+### 1-1. `escapeHtml` 누락 해결
+
+**파일:** `src/components/board/boardDetailUI.js`
+
+#### Before
+```javascript
+<h1 class="text-3xl font-bold text-[#1a3a35] leading-tight flex-1">
+  ${post.title}
+</h1>
+...
+<p id="comment-content-${comment.commentId}" class="...">${comment.content}</p>
+```
+
+#### After
+```javascript
+<h1 class="text-3xl font-bold text-[#1a3a35] leading-tight flex-1">
+  ${escapeHtml(post.title)}
+</h1>
+...
+<p id="comment-content-${comment.commentId}" class="...">${escapeHtml(comment.content)}</p>
+```
+
+#### 같은 파일에서 확인할 곳
+
+```javascript
+// 원래 좋은 부분 (이미 잘 돼 있음)
+${escapeHtml(categoryMap[post.category] ?? post.category)}
+${escapeHtml(post.nickname)}
+${escapeHtml(post.content.trim())}
+
+// 마저 적용해야 할 부분
+${escapeHtml(post.title)}            // 1번
+${escapeHtml(comment.content)}       // 2번
+${escapeHtml(comment.nickname)}      // 댓글 닉네임도 잊지 마세요
+${escapeHtml(preset.deckname)}       // 트레이너 카드 덱 이름도
+```
+
+#### 원칙 한 줄 요약
+
+> **사용자가 입력한 모든 텍스트는 화면에 그릴 때 `escapeHtml`로 감싸세요. 예외 없음.**
+
+---
+
+### 1-2. 인라인 `onclick="..."` 안의 사용자 데이터 제거
+
+**파일:** `src/components/board/boardDetail.js:166-185`
+
+#### Before — 위험한 코드
+```javascript
+window.toggleEditMode = (commentId) => {
+  const contentP = document.getElementById(`comment-content-${commentId}`);
+  const btnGroup = document.getElementById(`comment-btns-${commentId}`);
+  const originalContent = contentP.innerText;
+
+  contentP.innerHTML = `
+    <textarea id="edit-input-${commentId}" rows="3">${originalContent}</textarea>
+  `;
+
+  btnGroup.innerHTML = `
+    <button onclick="saveEditComment(${commentId}, '${originalContent}')">저장</button>
+    <button onclick="cancelEditMode(${commentId}, '${originalContent}')">취소</button>
+  `;
+};
+```
+
+#### After — `data-*` 속성 + `addEventListener`
+```javascript
+window.toggleEditMode = (commentId) => {
+  const contentP = document.getElementById(`comment-content-${commentId}`);
+  const btnGroup = document.getElementById(`comment-btns-${commentId}`);
+  const originalContent = contentP.textContent;  // innerText보다 textContent를 권장
+
+  // 1. textarea로 교체 — escapeHtml로 감싸기
+  contentP.innerHTML = `
+    <textarea id="edit-input-${commentId}"
+      class="w-full p-3 mt-2 border border-gray-200 rounded-lg ..."
+      rows="3">${escapeHtml(originalContent)}</textarea>
+  `;
+
+  // 2. 버튼 교체 — 인라인 onclick 대신 data-* 속성으로 정보 전달
+  btnGroup.innerHTML = `
+    <button data-action="save-comment" data-comment-id="${commentId}"
+            class="text-[11px] text-[#05B29F] font-bold">저장</button>
+    <button data-action="cancel-edit" data-comment-id="${commentId}"
+            class="text-[11px] text-gray-400 font-bold">취소</button>
+  `;
+
+  // 3. 새로 만든 버튼에 이벤트 직접 등록
+  btnGroup.querySelector('[data-action="save-comment"]').addEventListener('click', () => {
+    saveEditComment(commentId, originalContent);  // 클로저로 그대로 캡처 (HTML 직렬화 X)
+  });
+  btnGroup.querySelector('[data-action="cancel-edit"]').addEventListener('click', () => {
+    cancelEditMode(commentId, originalContent);
+  });
+};
+```
+
+#### 왜 더 안전할까요?
+- `originalContent`(사용자 데이터)가 **HTML 문자열로 직렬화되지 않아요**. JS 변수 그대로 클로저에 잡혀요.
+- 그래서 작은따옴표든 백슬래시든 `<script>`든 다 안전합니다.
+- 인라인 `onclick` 자체를 안 쓰니까 CSP(Content Security Policy)에도 친화적이에요.
+
+---
+
+### 1-3. `post`가 `null`일 때 안전하게 처리
+
+**파일:** `src/components/board/boardDetail.js:28-89`
+
+#### Before
+```javascript
+} catch (error) {
+  console.error(error);
+}                                          // catch는 했지만 실행은 계속됨
+const contentArea = document.getElementById("postDetailContent");
+const commentArea = document.getElementById("commentSection");
+
+if (contentArea) {
+  if (post.preset) {                       // 💥 post가 null이면 TypeError
+```
+
+#### After
+```javascript
+try {
+  const postRes = await fetch(`${BASE_URL}/posts/${postId}`);
+  const commentRes = await fetch(`${BASE_URL}/posts/${postId}/comments`);
+  if (!postRes.ok) throw new Error("게시물 불러오기 실패");
+  if (!commentRes.ok) throw new Error("댓글 불러오기 실패");
+
+  const postJson = await postRes.json();
+  const commentJson = await commentRes.json();
+
+  post = postJson.data;
+  comments = Array.isArray(commentJson.data) ? commentJson.data : [];
+} catch (error) {
+  console.error(error);
+  // 1. 에러 상태를 화면에 보여주기
+  const contentArea = document.getElementById("postDetailContent");
+  if (contentArea) {
+    contentArea.innerHTML = `
+      <div class="text-center py-20 text-gray-400">
+        <p class="text-lg font-bold">게시글을 불러오지 못했어요.</p>
+        <button onclick="location.href='/board'"
+                class="mt-4 px-4 py-2 bg-[#05B29F] text-white rounded-lg">
+          게시판으로 돌아가기
+        </button>
+      </div>
+    `;
+  }
+  return;   // 2. 함수 종료 — 다음 코드가 실행되지 않게
+}
+
+// 여기 이후는 post가 반드시 존재한다는 보장이 있음
+const contentArea = document.getElementById("postDetailContent");
+const commentArea = document.getElementById("commentSection");
+...
+```
+
+#### 핵심 원칙
+1. **에러를 잡았으면 사용자에게 알려주세요.** "조용히 실패"가 가장 나쁜 실패예요.
+2. **에러 후엔 `return`으로 함수를 끝내거나, 분명한 분기를 만드세요.** 그래야 그 다음 코드가 "데이터가 있다"고 가정해도 안전해요.
+
+---
+
+### 1-4. `errorData` ReferenceError 수정
+
+**파일:** `src/components/board/write.js:281-283`
+
+#### Before
+```javascript
+if (!editRes.ok) {
+  throw new Error(errorData.message || "수정 실패");   // errorData가 어디에도 없음
+}
+```
+
+#### After
+```javascript
+if (!editRes.ok) {
+  // 응답 본문에서 메시지 뽑아내기 (실패하더라도 안전하게)
+  let message = "수정 실패";
+  try {
+    const errorData = await editRes.json();
+    if (errorData?.message) message = errorData.message;
+  } catch {
+    // JSON 파싱 실패해도 기본 메시지 사용
+  }
+  throw new Error(message);
+}
+```
+
+#### 패턴 한 줄 요약
+> **변수를 쓰기 전에 그 변수가 어디서 왔는지 한 번 더 확인하세요.** 에디터의 "Go to definition" 단축키(Cmd+클릭)는 이런 버그 잡으라고 있는 거예요.
+
+---
+
+### 4-1. 작동하지 않는 `<script>` 블록 삭제
+
+**파일:** `src/components/pokedex/pokedexUI.js:565-585`
+
+#### Before
+```javascript
+return `
+  <div class="pm-modal-wrap" ...>
+    ...
+  </div>
+
+  <script>
+    (function() {
+      let idx = 0;
+      const TOTAL = 6;
+      window.pmSlide = function(dir) { ... };
+    })();
+  <\/script>
+`;
+};
+```
+
+#### After
+```javascript
+return `
+  <div class="pm-modal-wrap" ...>
+    ...
+  </div>
+`;
+};
+```
+
+이 `<script>` 블록은 `innerHTML`로 들어가서 **절대 실행되지 않아요**. 그냥 지우세요. 슬라이더 동작은 위쪽의 `setTimeout` 안 코드가 처리하고 있어요.
+
+> 만약 슬라이더 핸들러를 정리하고 싶다면 `setTimeout(0)` 패턴 자체를 없애야 해요. 그건 [3-2 항목](#3-2-pokedexuijs--style-주입--settimeout-패턴-제거)에서 다룰게요.
+
+---
+
+## 2. 🟠 높음 — 응집도/결합도 정리
+
+### 2-1. `window.*` 함수 박멸 — 이벤트 위임 패턴
+
+**문제 파일들:**
+- `pokedex.js` — `selectPokemon`, `poketmonReg`, `poketmonDelete`
+- `mypocketmon.js` — `selectPokemon` (중복!)
+- `myparty.js` — `poketmonDelete` (중복!)
+- `boardDetail.js` — `toggleEditMode`, `saveEditComment`, `cancelEditMode`, `handleDeleteComment`, `handleDeletePost`, `handleEditPost`
+
+#### 문제의 본질
+
+```javascript
+// pokedex.js
+window.selectPokemon = async (no) => { /* 도감용 로직 */ };
+
+// mypocketmon.js
+window.selectPokemon = async (no) => { /* 마이페이지용 로직 */ };
+```
+
+같은 이름이 두 곳에서 등록되면, **나중에 등록된 게 이긴다**. 도감 → 마이페이지 → 도감으로 이동하면 도감 화면에서 마이페이지 함수가 실행돼요.
+
+#### 해결: 이벤트 위임 (Event Delegation)
+
+> "버튼 하나하나에 핸들러를 다는 게 아니라, **부모 컨테이너 한 곳**에 핸들러를 달고 클릭된 게 어떤 버튼인지 판단한다"
+
+##### Step 1: HTML에 `data-action` 표시
+
+```javascript
+// pokedexUI.js — PokemonCard
+return `
+  <div class="group bg-white rounded-2xl ...">
+    <div data-action="select-pokemon" data-id="${data.id}"
+         class="relative h-44 ...">
+      <img src="${img}" class="w-28 h-28 ...">
+    </div>
+    <div class="p-6 ...">
+      ...
+      ${
+        isLoggedIn
+          ? myPocketMons.includes(data.id)
+            ? `<button data-action="poketmon-delete" data-id="${data.id}"
+                       class="w-7 h-7 ...">${pokeBallOn}</button>`
+            : `<button data-action="poketmon-reg" data-id="${data.id}"
+                       class="w-7 h-7 ...">${pokeBallOff}</button>`
+          : ""
+      }
+    </div>
+  </div>
+`;
+```
+
+→ `onclick="..."` 가 다 사라지고, 누구의 버튼인지를 `data-action`/`data-id`로만 표시.
+
+##### Step 2: 그리드 컨테이너에 한 번만 핸들러
+
+```javascript
+// pokedex.js
+function bindGridEvents() {
+  const grid = document.getElementById("pokemonGrid");
+  if (!grid) return;
+
+  grid.addEventListener("click", async (e) => {
+    const target = e.target.closest("[data-action]");
+    if (!target) return;
+
+    const action = target.dataset.action;
+    const id = Number(target.dataset.id);
+
+    if (action === "select-pokemon") {
+      openPokemonModal(id);             // 더 이상 window.* 가 아님
+    } else if (action === "poketmon-reg") {
+      e.stopPropagation();
+      await registerPokemon(id);
+    } else if (action === "poketmon-delete") {
+      e.stopPropagation();
+      await deletePokemonBookmark(id);
+    }
+  });
+}
+
+async function openPokemonModal(no) {
+  const modal = document.getElementById("pokemon-modal");
+  ...
+}
+
+async function registerPokemon(id) {
+  await poketmonReg(id);
+  myPocketMons.push(id);
+  renderGrid(currentPage);
+}
+```
+
+##### Step 3: `mypocketmon.js`도 동일하게
+
+마이페이지의 그리드는 `#my-pokemon-grid`예요. 같은 패턴으로 자기 컨테이너에만 이벤트 위임을 걸면, 도감과 마이페이지가 **서로 모르는 사이**가 돼요. = 결합도 0.
+
+#### 얻는 것
+
+| 전(window.\*)            | 후(이벤트 위임)             |
+| ------------------------ | --------------------------- |
+| 같은 이름 충돌 위험      | 충돌 불가능                 |
+| 카드 100개 → 핸들러 100개 | 컨테이너 1개 → 핸들러 1개   |
+| 새로 그릴 때마다 재바인드 필요 | 컨테이너에 한 번만           |
+| HTML 안에 JS 로직 (XSS 위험) | HTML은 데이터, JS는 로직   |
+| 어디서 호출되는지 모름   | 한 컨테이너 안에서만 동작   |
+
+---
+
+### 2-2. 모듈 최상단의 mutable 상태 줄이기
+
+**파일:** `src/components/myparty/myparty.js`
+
+#### 단계 1: 화면 진입 시마다 초기화하는 `init` 함수
+
+```javascript
+// 변경 전: 모듈 최상단
+let selectedSlot = null;
+let party = Array(6).fill(null);
+let gender = "man";
+let pokemons = [];
+let presets = [];
+...
+
+// 변경 후: state 객체 + init에서 초기화
+const state = {
+  selectedSlot: null,
+  party: Array(6).fill(null),
+  gender: "man",
+  loadedPresetIndex: null,
+  pokemons: [],
+  presets: [],
+  searchQuery: "",
+};
+
+const refs = {
+  root: null,
+  list: null,
+  count: null,
+  presetList: null,
+  presetCount: null,
+};
+
+export async function init() {
+  // 1. 진입할 때마다 state를 새 객체로 (이전 진입 잔존 X)
+  Object.assign(state, {
+    selectedSlot: null,
+    party: Array(6).fill(null),
+    gender: "man",
+    loadedPresetIndex: null,
+    pokemons: [],
+    presets: [],
+    searchQuery: "",
+  });
+
+  refs.root = document.getElementById("trainer-card-root");
+  refs.list = document.getElementById("pokemon-list");
+  refs.count = document.getElementById("count");
+  refs.presetList = document.getElementById("preset-list");
+  refs.presetCount = document.getElementById("preset-count");
+
+  if (!refs.root) return;
+
+  await loadBookmarkedPokemons();
+  await loadPartyPresets();
+
+  renderTrainerCard();
+  renderList();
+  renderPresets();
+  bindEvents();
+}
+```
+
+#### 왜 이렇게 할까요?
+- 한 객체(`state`)로 모으면 **어떤 변수가 이 화면의 상태인지** 한눈에 보여요.
+- `init()`에서 매번 초기화하면 페이지 재진입 시 잔존 상태가 사라져요.
+- 다른 함수에서는 `state.party`, `state.pokemons` 처럼 접근하면 됩니다.
+
+---
+
+### 2-3. `write.js` 모듈 최상단 토큰 제거
+
+**파일:** `src/components/board/write.js`
+
+#### Before
+```javascript
+let uploadImgUrl = "";
+const token = localStorage.getItem("token");   // ❌ 모듈 로드 시점 1회
+let loadPreset = [];
+```
+
+#### After
+```javascript
+// 모듈 최상단에는 변하지 않는 상수만!
+// 토큰은 매번 함수 안에서 가져온다.
+
+function authHeaders() {
+  return {
+    Authorization: `Bearer ${localStorage.getItem("token") || ""}`,
+  };
+}
+```
+
+그리고 이미지 업로드 부분도:
+
+```javascript
+document.getElementById("write-image").addEventListener("change", async (e) => {
+  const file = e.target.files[0];
+  if (!file) return;
+
+  const formData = new FormData();
+  formData.append("file", file);
+
+  const uploadRes = await fetch(`${BASE_URL}/images`, {
+    method: "POST",
+    headers: authHeaders(),                    // ✅ 매번 새로
+    body: formData,
+  });
+  ...
+});
+```
+
+`uploadImgUrl`, `loadPreset`도 모듈 변수에서 빼서 `initWrite` 함수의 지역 변수로 옮기는 게 좋아요. 그러면 페이지를 떠났다 다시 들어왔을 때 깨끗한 상태로 시작합니다.
+
+---
+
+### 2-4. `modal.js` 확장 — 입력형 모달 지원
+
+**파일:** `src/components/modal.js`
+
+지금 `modal.js`는 알림(확인 1개) 만 지원해요. 그래서 `myparty.js`가 직접 `preset-modal` HTML을 만들어 쓰고 있죠. 모달 시스템을 하나로 통합합시다.
+
+#### 새 시그니처
+
+```javascript
+const MODAL_ID = 'custom-modal';
+
+function injectModal() {
+  if (document.getElementById(MODAL_ID)) return;
+
+  const el = document.createElement('div');
+  el.innerHTML = `
+    <div id="${MODAL_ID}" class="fixed inset-0 z-50 items-center justify-center hidden">
+      <div id="${MODAL_ID}-overlay" class="absolute inset-0 bg-black/40 backdrop-blur-sm"></div>
+      <div class="relative bg-white rounded-2xl shadow-xl w-full max-w-sm mx-4 p-6 flex flex-col gap-5">
+        <div>
+          <h3 id="${MODAL_ID}-title" class="text-lg font-black text-slate-900">알림</h3>
+          <p id="${MODAL_ID}-desc" class="text-sm text-slate-400 mt-1"></p>
+        </div>
+        <input id="${MODAL_ID}-input" type="text"
+               class="w-full rounded-xl px-4 py-2 text-sm outline-none border border-gray-200 hidden" />
+        <div class="flex gap-2">
+          <button id="${MODAL_ID}-cancel"
+                  class="hidden flex-1 rounded-xl px-4 py-2 text-sm font-semibold border border-gray-300 text-gray-600 hover:bg-gray-50">
+            취소
+          </button>
+          <button id="${MODAL_ID}-confirm"
+                  class="flex-1 rounded-xl px-4 py-2 bg-teal-500 text-white text-sm font-semibold hover:bg-teal-600 transition">
+            확인
+          </button>
+        </div>
+      </div>
+    </div>
+  `;
+  document.body.appendChild(el.firstElementChild);
+}
+
+function closeModal() {
+  const modal = document.getElementById(MODAL_ID);
+  if (!modal) return;
+  modal.classList.add('hidden');
+  modal.classList.remove('flex');
+}
+
+// 1. 알림 모달 (기존 호환)
+export function showModal(title, desc) {
+  return openModal({ title, desc, type: 'alert' });
+}
+
+// 2. 확인/취소 모달
+export function showConfirm(title, desc) {
+  return openModal({ title, desc, type: 'confirm' });
+  // resolve(true) = 확인, resolve(false) = 취소
+}
+
+// 3. 입력 모달
+export function showPrompt(title, desc, defaultValue = '') {
+  return openModal({ title, desc, type: 'prompt', defaultValue });
+  // resolve(string) = 입력값, resolve(null) = 취소
+}
+
+// 내부 통합 함수
+function openModal({ title, desc, type, defaultValue = '' }) {
+  injectModal();
+
+  const modal = document.getElementById(MODAL_ID);
+  const titleEl = document.getElementById(`${MODAL_ID}-title`);
+  const descEl = document.getElementById(`${MODAL_ID}-desc`);
+  const inputEl = document.getElementById(`${MODAL_ID}-input`);
+  const confirmEl = document.getElementById(`${MODAL_ID}-confirm`);
+  const cancelEl = document.getElementById(`${MODAL_ID}-cancel`);
+  const overlayEl = document.getElementById(`${MODAL_ID}-overlay`);
+
+  titleEl.textContent = title;
+  descEl.textContent = desc;
+
+  // type별로 input/cancel 보이기/숨기기 (Tailwind 클래스 토글)
+  inputEl.classList.toggle('hidden', type !== 'prompt');
+  cancelEl.classList.toggle('hidden', type === 'alert');
+
+  if (type === 'prompt') {
+    inputEl.value = defaultValue;
+    setTimeout(() => inputEl.focus(), 0);
+  }
+
+  modal.classList.remove('hidden');
+  modal.classList.add('flex');
+
+  return new Promise((resolve) => {
+    function cleanup() {
+      confirmEl.removeEventListener('click', onConfirm);
+      cancelEl.removeEventListener('click', onCancel);
+      overlayEl.removeEventListener('click', onCancel);
+    }
+    function onConfirm() {
+      cleanup();
+      closeModal();
+      if (type === 'prompt') resolve(inputEl.value.trim() || null);
+      else if (type === 'confirm') resolve(true);
+      else resolve();
+    }
+    function onCancel() {
+      cleanup();
+      closeModal();
+      if (type === 'prompt') resolve(null);
+      else if (type === 'confirm') resolve(false);
+      else resolve();
+    }
+    confirmEl.addEventListener('click', onConfirm);
+    cancelEl.addEventListener('click', onCancel);
+    overlayEl.addEventListener('click', onCancel);
+  });
+}
+```
+
+#### 사용 예시
+
+```javascript
+// boardDetail.js
+import { showModal, showConfirm } from "../modal.js";
+
+if (!text.trim()) {
+  await showModal("입력 필요", "댓글 내용을 입력해주세요.");
+  return;
+}
+
+const ok = await showConfirm("게시글 삭제", "정말 삭제하시겠습니까?");
+if (!ok) return;
+await deletePost(postId);
+```
+
+```javascript
+// myparty.js — 더 이상 preset-modal HTML 필요 없음
+import { showModal, showConfirm, showPrompt } from "../modal.js";
+
+document.getElementById("saveBtn")?.addEventListener("click", async () => {
+  if (state.party.filter(Boolean).length === 0) {
+    await showModal("포켓몬 미선택", "포켓몬을 하나 이상 선택해주세요.");
+    return;
+  }
+
+  if (state.loadedPresetIndex !== null) {
+    const preset = state.presets[state.loadedPresetIndex];
+    const ok = await showConfirm("파티 덮어쓰기", `"${preset.name}"에 현재 구성을 덮어씁니다.`);
+    if (ok) await updatePreset(state.loadedPresetIndex);
+    return;
+  }
+
+  const name = await showPrompt("파티 이름", "나만의 파티 이름을 입력해주세요");
+  if (name) await savePreset(name);
+});
+```
+
+#### 얻는 것
+- `myparty.html`의 `preset-modal` 블록 전체 **삭제 가능**
+- `mypage.html`의 `logout-modal`, `withdraw-modal` 블록도 같은 방식으로 **삭제 가능**
+- 모달 디자인을 한 곳에서 관리 → 일관성 100%
+
+---
+
+## 3. 🟠 높음 — Tailwind로 스타일 정리
+
+### 3-1. 인라인 `style="..."` → Tailwind 클래스
+
+#### 변환 치트시트 (자주 쓰는 것들)
+
+| 인라인 스타일                       | Tailwind                  |
+| ----------------------------------- | ------------------------- |
+| `style="padding: 24px"`             | `p-6`                     |
+| `style="padding: 0 12px"`           | `px-3`                    |
+| `style="margin-bottom: 24px"`       | `mb-6`                    |
+| `style="gap: 16px"`                 | `gap-4`                   |
+| `style="display: flex"`             | `flex`                    |
+| `style="flex-direction: column"`    | `flex-col`                |
+| `style="border-radius: 12px"`       | `rounded-xl`              |
+| `style="background: #fff"`          | `bg-white`                |
+| `style="font-size: 13px"`           | `text-[13px]`             |
+| `style="color: #9ca3af"`            | `text-gray-400`           |
+| `style="border: 1px solid #d1d5db"` | `border border-gray-300`  |
+
+> Tailwind의 기본 spacing은 4px 단위예요. `p-1`=4px, `p-2`=8px, `p-3`=12px, `p-4`=16px, `p-6`=24px... 이런 식.
+
+#### 예시 1: `boardDetailUI.js` 트레이너 카드
+
+##### Before
+```html
+<div style="width: 100%; max-width: 600px; margin: 24px auto;">
+  ${
+    post.preset.deckname
+      ? `<p style="font-size: 13px; font-weight: 700; color: #6b7280; margin-bottom: 8px; text-align: center;">
+            ${post.preset.deckname}
+         </p>`
+      : ""
+  }
+  <div style="position: relative; width: 100%; border-radius: 12px; overflow: hidden;">
+```
+
+##### After
+```html
+<div class="w-full max-w-[600px] mx-auto my-6">
+  ${
+    post.preset.deckname
+      ? `<p class="text-[13px] font-bold text-gray-500 mb-2 text-center">
+            ${escapeHtml(post.preset.deckname)}
+         </p>`
+      : ""
+  }
+  <div class="relative w-full rounded-xl overflow-hidden">
+```
+
+##### 주의: 슬롯 좌표는 동적이라 인라인 OK
+```javascript
+${SLOT_POSITIONS.map((pos, i) => `
+  <div class="absolute w-[20%] h-[17%]"
+       style="top: ${pos.top}; left: ${pos.left};">
+    ...
+  </div>
+`).join("")}
+```
+
+→ 동적으로 변하는 값(`top`, `left`)은 인라인 스타일이어도 OK. **반복되거나 정적인 스타일만 Tailwind로 옮기세요.**
+
+#### 예시 2: `myparty.js` 프리셋 슬롯
+
+##### Before (61줄)
+```javascript
+return `
+  <button type="button" data-new-slot="${slotIndex}"
+    style="width:100%; padding:10px; border-radius:12px; border:1.5px dashed #d1d5db;
+           background:#f8fafc; color:#9ca3af; font-size:13px; font-weight:600;
+           cursor:pointer; transition:all 0.15s; text-align:center;
+           ${isLoaded ? 'outline:2px solid #5eead4; outline-offset:1px;' : ''}"
+    onmouseover="this.style.borderColor='#5eead4'; this.style.color='#0d9488'; this.style.background='#f0fdfa';"
+    onmouseout="this.style.borderColor='#d1d5db'; this.style.color='#9ca3af'; this.style.background='#f8fafc';">
+    + 새 파티 저장
+  </button>
+`;
+```
+
+##### After (호버까지 한 줄)
+```javascript
+return `
+  <button type="button" data-new-slot="${slotIndex}"
+    class="w-full p-2.5 rounded-xl border-[1.5px] border-dashed border-gray-300 bg-slate-50
+           text-gray-400 text-[13px] font-semibold cursor-pointer text-center
+           hover:border-teal-300 hover:text-teal-600 hover:bg-teal-50 transition-colors
+           ${isLoaded ? 'outline outline-2 outline-teal-300 outline-offset-1' : ''}">
+    + 새 파티 저장
+  </button>
+`;
+```
+
+#### 핵심
+- `onmouseover`/`onmouseout`는 **Tailwind의 `hover:` prefix로 100% 대체 가능**해요.
+- 인라인 onmouseover는 인라인 onclick과 똑같이 위험한 패턴이에요.
+
+---
+
+### 3-2. `pokedexUI.js` — `<style>` 주입 + `setTimeout` 패턴 제거
+
+**파일:** `src/components/pokedex/pokedexUI.js:259-381, 565-585`
+
+#### Before — 동적 `<style>` + `setTimeout` 후 DOM 접근
+```javascript
+if (!document.getElementById("pm-modal-styles")) {
+  const style = document.createElement("style");
+  style.id = "pm-modal-styles";
+  style.textContent = `
+    @media (min-width: 790px) {
+      .pm-bottom-grid   { display: grid !important; }
+      .pm-bottom-slider { display: none !important; }
+    }
+    @media (max-width: 789px) {
+      .pm-modal-wrap { ... }
+      ...
+    }
+  `;
+  document.head.appendChild(style);
+}
+
+setTimeout(() => {
+  const inner = document.getElementById("pmSliderInner");
+  ...
+}, 0);
+```
+
+#### After — Tailwind 반응형 + initPokemonModal 함수 분리
+
+##### Step 1: HTML에서 Tailwind 클래스 사용
+```javascript
+// 데스크탑 grid (md 이상에서만 보임)
+<div class="hidden md:grid grid-cols-6 gap-2 p-3">
+  ${sprites.map((s) => `
+    <div class="rounded-xl border border-white/60 bg-white/20 flex flex-col items-center justify-center gap-1 p-2">
+      ${s.src ? `<img src="${s.src}" class="w-11 h-11 object-contain"/>` : ''}
+      <span class="text-[10px] text-white/85 font-medium">${s.label}</span>
+    </div>
+  `).join('')}
+</div>
+
+// 모바일 슬라이더 (md 미만에서만 보임)
+<div class="flex md:hidden items-center gap-2 px-3.5 pb-3.5 relative h-[110px]">
+  <button class="pm-arrow-btn" data-pm-arrow="prev" disabled>&#8249;</button>
+  <div class="flex-1 overflow-hidden rounded-xl mx-11">
+    <div class="flex gap-2 transition-transform" id="pmSliderInner">
+      ...
+    </div>
+  </div>
+  <button class="pm-arrow-btn" data-pm-arrow="next">&#8250;</button>
+</div>
+```
+
+→ `@media` 쿼리 하나도 안 썼는데 반응형 끝.
+
+##### Step 2: 슬라이더 로직을 별도 함수로 export
+```javascript
+// pokedexUI.js
+export function initPokemonModalSlider(modalRoot) {
+  const inner = modalRoot.querySelector("#pmSliderInner");
+  if (!inner) return;
+
+  let idx = 0;
+  const total = inner.children.length;
+
+  function move(dir) {
+    idx = Math.max(0, Math.min(idx + dir, total - 1));
+    const slideW = inner.children[0]?.offsetWidth || 0;
+    inner.style.transform = `translateX(-${idx * (slideW + 8)}px)`;
+
+    const prev = modalRoot.querySelector('[data-pm-arrow="prev"]');
+    const next = modalRoot.querySelector('[data-pm-arrow="next"]');
+    if (prev) prev.disabled = idx === 0;
+    if (next) next.disabled = idx === total - 1;
+  }
+
+  modalRoot.addEventListener("click", (e) => {
+    const arrow = e.target.closest("[data-pm-arrow]");
+    if (!arrow) return;
+    move(arrow.dataset.pmArrow === "prev" ? -1 : 1);
+  });
+}
+```
+
+##### Step 3: 호출 쪽에서 한 줄 추가
+```javascript
+// pokedex.js (또는 mypocketmon.js)
+import { PokemonModalContent, initPokemonModalSlider } from "./pokedexUI.js";
+
+content.innerHTML = PokemonModalContent(data, p.name, species);
+initPokemonModalSlider(content);   // ✅ DOM 삽입 후 명시적으로 호출
+```
+
+#### 얻는 것
+- `<style>` 동적 주입 코드 **전부 삭제**
+- `setTimeout(0)` 패턴 **제거** (명시적 함수 호출로 의도 분명)
+- `!important` 0개
+- `@media` 0개 (Tailwind가 다 함)
+
+---
+
+### 3-3. `mypocketmonUI.js` — `<style>` 태그 제거
+
+##### Before
+```javascript
+return `
+  <div class="bg-white rounded-2xl" style="padding: 24px;">
+    ...
+    <style>
+      #my-pokemon-grid { display: grid; ... }
+      @media (min-width: 461px)  { #my-pokemon-grid { grid-template-columns: repeat(2, ...); } }
+      ...
+    </style>
+    <div id="my-pokemon-grid"></div>
+  </div>
+`;
+```
+
+##### After
+```javascript
+return `
+  <div class="bg-white rounded-2xl p-6">
+    <h2 class="text-xl font-bold text-[#1a3a35] mb-6">
+      내가 지닌 포켓몬 <span class="whitespace-nowrap"><span class="text-[#00bba7]">${count}</span>마리</span>
+    </h2>
+    <div class="overflow-y-auto max-h-[70vh] [scrollbar-width:thin] [scrollbar-color:#00bba7_transparent]">
+      <div id="my-pokemon-grid"
+           class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 gap-4"></div>
+    </div>
+  </div>
+`;
+```
+
+→ 13줄의 `<style>` 블록이 한 줄(`grid grid-cols-1 sm:...`)로 끝.
+
+---
+
+## 4. 🟡 보통 — 정리 & 일관성
+
+### 4-1. `console.log` 일괄 제거
+
+```bash
+# 찾는 명령
+grep -rn "console.log" src/components/board src/components/myparty
+```
+
+찾은 결과를 하나씩 확인하고:
+- 진짜 디버그용 → 삭제
+- 정말 로깅이 필요한 곳 → `console.error` (에러일 때만)
+
+> PR을 만들기 직전, **항상** `git diff` 로 새로 추가한 코드를 한 번 훑으세요. 거의 매번 `console.log` 한두 개는 남아 있어요.
+
+---
+
+### 4-2. dead code (`openSaveModal`) 삭제
+
+```javascript
+// myparty.js:349-417
+async function openSaveModal() {  // ← 통째로 삭제
+  ...
+}
+```
+
+> "혹시 나중에 쓸지 몰라서 둔다"는 함정이에요. **git이 다 기억하고 있으니** 안심하고 지우세요. 필요하면 `git log -p` 로 언제든 꺼낼 수 있어요.
+
+---
+
+### 4-3. `escapeHtml` 중복 정의 제거
+
+```javascript
+// myparty.js 상단
+import { escapeHtml } from "../../utils/escapeHtml.js";
+import { TrainerCard } from "./trainerCard.js";
+import { PokemonCard } from "../pokedex/pokedexUI";
+import { showModal, showConfirm, showPrompt } from "../modal.js";
+
+// myparty.js 하단의 663~667줄 — 통째로 삭제!
+// function escapeHtml(text) { ... }
+```
+
+---
+
+### 4-4. `PokemonModalContent` 시그니처 통일
+
+#### Option A: 북마크 표시를 모달에도 보여줄 거면
+
+```javascript
+// pokedexUI.js
+export const PokemonModalContent = (data, koName, species, isBookmarked = false) => {
+  ...
+  // 모달 안 어딘가에서 사용
+  ${isBookmarked ? '<span class="...">★ 북마크됨</span>' : ''}
+  ...
+};
+```
+
+#### Option B: 안 쓸 거면 호출자에서 빼기
+
+```javascript
+// mypocketmon.js
+content.innerHTML = PokemonModalContent(data, p.name, species);   // 4번째 인자 제거
+```
+
+→ **둘 중 하나로 통일.** 안 쓰는 인자를 넘기는 코드는 미래의 본인을 헷갈리게 해요.
+
+---
+
+## 5. 💎 보너스: 작은 리팩터링 패턴
+
+### 5-1. fetch 헬퍼 함수 만들기
+
+매번 같은 패턴의 fetch 코드가 반복돼요:
+
+```javascript
+// 반복 코드
+const token = localStorage.getItem("token");
+const res = await fetch(`${BASE_URL}/posts/${postId}`, {
+  method: "DELETE",
+  headers: { Authorization: `Bearer ${token}` },
+});
+if (!res.ok) throw new Error("...");
+return res.json();
+```
+
+이걸 헬퍼로 묶으면:
+
+```javascript
+// src/api/http.js (새 파일)
+const BASE_URL = import.meta.env.VITE_BASE_URL;
+
+function authHeaders(extra = {}) {
+  const token = localStorage.getItem("token");
+  return {
+    ...extra,
+    ...(token ? { Authorization: `Bearer ${token}` } : {}),
+  };
+}
+
+export async function apiGet(path) {
+  const res = await fetch(`${BASE_URL}${path}`, { headers: authHeaders() });
+  if (!res.ok) throw new Error(`GET ${path} 실패: ${res.status}`);
+  return res.json();
+}
+
+export async function apiPost(path, body) {
+  const res = await fetch(`${BASE_URL}${path}`, {
+    method: "POST",
+    headers: authHeaders({ "Content-Type": "application/json" }),
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) throw new Error(`POST ${path} 실패: ${res.status}`);
+  return res.json();
+}
+
+export async function apiPut(path, body) { ... }
+export async function apiDelete(path) { ... }
+```
+
+이제 호출자는:
+
+```javascript
+import { apiPost, apiDelete } from "../../api/http.js";
+
+await apiPost(`/posts/${postId}/comments`, { content: text });
+await apiDelete(`/comments/${commentId}`);
+```
+
+→ 토큰 관리, 헤더, 에러 처리 모두 한 곳에서. **결합도 제로.**
+
+---
+
+### 5-2. `myparty.js` 쪼개기 제안
+
+```
+src/components/myparty/
+├── myparty.js                # init() 만 + 다른 모듈 조립
+├── myparty.state.js          # state, refs
+├── myparty.api.js            # fetch 4종 (load, save, update, delete)
+├── myparty.render.js         # render* 함수들
+├── myparty.events.js         # bind* 함수들
+└── trainerCard.js            # 이미 있음
+```
+
+이렇게 하면 한 파일이 100줄 안팎으로 줄어서 **눈으로 따라가기 쉬워져요**.
+
+> 처음부터 이렇게까지 쪼갤 필요는 없어요. **파일이 500줄 넘어가면** 분리를 고민하세요.
+
+---
+
+## 6. 체크리스트
+
+리뷰 항목별로 끝났는지 체크할 수 있어요. 이걸 PR 본문에 그대로 복사해서 진행 상황을 표시해도 좋아요.
+
+### 🔴 매우높음
+- [ ] 1-1. `boardDetailUI.js` `escapeHtml` 누락 부분 모두 적용
+- [ ] 1-2. `boardDetail.js` 인라인 onclick의 사용자 데이터 제거 (data-* 속성으로 전환)
+- [ ] 1-3. `boardDetail.js` `post === null`일 때 에러 화면 + return
+- [ ] 1-4. `write.js` `errorData` ReferenceError 수정
+- [ ] 4-1. `pokedexUI.js` 의미 없는 `<script>` 블록 삭제
+
+### 🟠 높음
+- [ ] 1-5. `window.*` 함수 박멸 → 이벤트 위임으로 전환 (pokedex / mypocketmon / myparty / boardDetail)
+- [ ] 2-1. `myparty.js` 모듈 상태를 `state` 객체로 + `init()`에서 초기화
+- [ ] 2-2. `write.js` 모듈 최상단 `token` 제거 → `authHeaders()` 사용
+- [ ] 2-4. `modal.js`에 `showConfirm`, `showPrompt` 추가
+- [ ] 2-4. `myparty.html`의 `preset-modal` 삭제 + `myparty.js`가 통합 모달 사용
+- [ ] 2-4. `mypage.html`의 `logout-modal`, `withdraw-modal` 삭제 + `showConfirm` 사용
+- [ ] 3-1. `boardDetailUI.js` 인라인 스타일 → Tailwind
+- [ ] 3-1. `myparty.js` 인라인 스타일 + `onmouseover`/`onmouseout` → Tailwind `hover:`
+- [ ] 3-1. `write.js` 인라인 스타일 → Tailwind
+- [ ] 3-2. `pokedexUI.js` `<style>` 동적 주입 제거 + Tailwind 반응형
+- [ ] 3-2. `pokedexUI.js` `setTimeout(0)` 패턴 → 명시적 `initPokemonModalSlider(modalRoot)` 함수
+- [ ] 3-3. `mypocketmonUI.js` `<style>` 태그 제거
+
+### 🟡 보통
+- [ ] 4-2. `mypocketmon.js` `PokemonModalContent` 4번째 인자 제거(또는 함수 시그니처 확장)
+- [ ] 4-3. `boardDetail.js` `console.log(post, "post")` 삭제
+- [ ] 4-4. `write.js` `console.log` 5개 모두 삭제
+- [ ] 5-1. `boardDetail.js` 모든 `alert()` → `showModal`/`showConfirm`
+- [ ] 5-2. `write.js` 모든 `alert()` → `showModal`/`showConfirm`
+- [ ] 2-3. `myparty.js` `openSaveModal()` dead code 삭제
+- [ ] 2-3. `myparty.js` 로컬 `escapeHtml` 함수 삭제 + import 사용
+- [ ] 6-1. `mypage.html` 로그아웃/탈퇴 모달 통합
+
+### 💎 보너스
+- [ ] 5-1. `src/api/http.js` fetch 헬퍼 만들기
+- [ ] 5-2. `myparty.js` 모듈 분리
+
+---
+
+힘내세요! 한 항목씩 차근차근 고쳐나가면, 다음 리뷰에선 분명히 또 칭찬받을 거예요. 💪
+
+코드를 고치다가 막히면 언제든 물어보세요. 한 번 알려준 패턴을 다른 곳에도 적용하는 게 가장 빠른 학습이에요.


### PR DESCRIPTION
## Summary

`abd7e76` 머지 이후 추가된 8개 커밋 변경사항에 대한 4차 증분 코드 리뷰입니다.
**boardDetail / write / myparty / pokedex / mypocketmon / modal.js** 가 대상이며,
응집도-결합도 관점에서 정리했습니다.

- `docs/2026041410_리뷰.md` — 22개 항목 코드 리뷰 (보안/버그/응집도/스타일/정리)
- `docs/2026041410_리뷰_해결.md` — Before/After 코드 + 체크리스트

## 핵심 발견 (꼭 봐주세요)

### 🔴 매우높음 (즉시 수정)
- **XSS** — `boardDetailUI.js` 에서 `post.title`, `comment.content`에 `escapeHtml` 누락
- **XSS** — `boardDetail.js` 의 인라인 `onclick="saveEditComment(${id}, '${originalContent}')"` 안에 사용자 데이터 직접 삽입
- **버그** — `boardDetail.js` 에서 `post`가 `null`인 채로 `post.preset` 접근 → TypeError
- **버그** — `write.js:282` `throw new Error(errorData.message)` 에서 `errorData`가 정의되지 않은 ReferenceError
- **버그** — `pokedexUI.js` 반환 문자열 안의 `<script>` 태그는 innerHTML 삽입 시 실행되지 않음 (dead code)

### 🟠 높음 (응집도/결합도)
- `window.selectPokemon`, `window.poketmonDelete` 가 `pokedex.js`/`mypocketmon.js`/`myparty.js`에서 **중복 등록** → 페이지 이동 시 충돌
- `myparty.js` 모듈 최상단의 mutable 상태 12개 → 페이지 재진입 시 잔존
- `write.js` 모듈 최상단에서 `localStorage.getItem("token")` 한 번만 평가
- `myparty.js`가 `modal.js` (showModal) + `preset-modal` HTML **두 가지 모달 시스템 혼재**
- 인라인 `style="..."` + `onmouseover`/`onmouseout` 패턴 다수 → Tailwind 미사용

## 해결 가이드 핵심 패턴

1. **이벤트 위임** — `window.*` 박멸, 컨테이너 1개에 핸들러 1개
2. **`modal.js` 확장** — `showConfirm` / `showPrompt` 추가하여 mypage.html / myparty.html 의 모든 모달 통합
3. **Tailwind 변환표** — `style="..."` → 클래스, `onmouseover` → `hover:`
4. **`<style>` 동적 주입 제거** — Tailwind 반응형(`md:hidden` `md:grid`) 사용
5. **`setTimeout(0)` 패턴 제거** — 명시적 `initPokemonModalSlider(modalRoot)` 함수로 분리
6. **fetch 헬퍼 (`apiGet`/`apiPost`/`apiDelete`)** — 토큰/에러 처리 일원화

## Test plan

- [ ] `docs/2026041410_리뷰.md` 가독성 확인
- [ ] `docs/2026041410_리뷰_해결.md` 의 Before/After 코드가 컴파일 가능한지 확인
- [ ] 체크리스트로 진행 상황 추적 가능한지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)